### PR TITLE
Add authentication predicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.ensime
+.ensime_cache/
+ensime-langserver.log
+ensime.sbt
+pc.stdout.log
 .cache
 /.classpath
 db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Trusts frontend
+
+This project is a Scala web application for the registration of trusts using [code scaffolds](https://github.com/hmrc/hmrc-frontend-scaffold.g8)
+
+## Get started
+
+Follow these instructions so you can get a copy of the project on your local machine.  You can use this to develop and test the service.
+
+### Before you get started
+
+This service written in Scala and Play 2.5.  It needs:
+
+- at least a [JRE 1.8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to run
+
+- [sbt](https://www.scala-sbt.org/) to test, build and run a development version
+
+## Tests
+
+### Unit tests
+
+- Inside the trusts-frontend folder run `sbt test` to run unit tests for the service.
+
+## Licence
+
+This project is licensed under the [Apache 2.0 License](LICENSE). 


### PR DESCRIPTION
- Users must be enrolled as an Agent with an Agent Services Account or
as an Organisation