### PR TITLE
TRUS-463 Trust Details

### DIFF
--- a/.g8/datePage/app/controllers/$className$Controller.scala
+++ b/.g8/datePage/app/controllers/$className$Controller.scala
@@ -20,7 +20,7 @@ class $className$Controller @Inject()(
                                                   sessionRepository: SessionRepository,
                                                   navigator: Navigator,
                                                   identify: IdentifierAction,
-                                                  getData: AfaDataRetrievalActionProvider,
+                                                  getData: DataRetrievalAction,
                                                   requireData: DataRequiredAction,
                                                   formProvider: $className$FormProvider,
                                                   val controllerComponents: MessagesControllerComponents,
@@ -29,7 +29,7 @@ class $className$Controller @Inject()(
 
   val form = formProvider()
 
-  def onPageLoad(mode: Mode, afaId: AfaId): Action[AnyContent] = (identify andThen getData(afaId) andThen requireData) {
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
       val preparedForm = request.userAnswers.get($className$Page) match {
@@ -37,7 +37,7 @@ class $className$Controller @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, mode, afaId))
+      Ok(view(preparedForm, mode))
   }
 
   def onSubmit(mode: Mode, afaId: AfaId): Action[AnyContent] = (identify andThen getData(afaId) andThen requireData).async {
@@ -45,7 +45,7 @@ class $className$Controller @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, mode, afaId))),
+          Future.successful(BadRequest(view(formWithErrors, mode))),
 
         value => {
           for {

--- a/.g8/datePage/app/controllers/$className$Controller.scala
+++ b/.g8/datePage/app/controllers/$className$Controller.scala
@@ -3,7 +3,7 @@ package controllers
 import controllers.actions._
 import forms.$className$FormProvider
 import javax.inject.Inject
-import models.{AfaId, Mode}
+import models.Mode
 import navigation.Navigator
 import pages.$className$Page
 import play.api.data.Form
@@ -40,7 +40,7 @@ class $className$Controller @Inject()(
       Ok(view(preparedForm, mode))
   }
 
-  def onSubmit(mode: Mode, afaId: AfaId): Action[AnyContent] = (identify andThen getData(afaId) andThen requireData).async {
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
 
       form.bindFromRequest().fold(

--- a/.g8/datePage/app/controllers/$className$Controller.scala
+++ b/.g8/datePage/app/controllers/$className$Controller.scala
@@ -1,0 +1,58 @@
+package controllers
+
+import controllers.actions._
+import forms.$className$FormProvider
+import javax.inject.Inject
+import models.{AfaId, Mode}
+import navigation.Navigator
+import pages.$className$Page
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.$className$View
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class $className$Controller @Inject()(
+                                                  override val messagesApi: MessagesApi,
+                                                  sessionRepository: SessionRepository,
+                                                  navigator: Navigator,
+                                                  identify: IdentifierAction,
+                                                  getData: AfaDataRetrievalActionProvider,
+                                                  requireData: DataRequiredAction,
+                                                  formProvider: $className$FormProvider,
+                                                  val controllerComponents: MessagesControllerComponents,
+                                                  view: $className$View
+                                                )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode, afaId: AfaId): Action[AnyContent] = (identify andThen getData(afaId) andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get($className$Page) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode, afaId))
+  }
+
+  def onSubmit(mode: Mode, afaId: AfaId): Action[AnyContent] = (identify andThen getData(afaId) andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode, afaId))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set($className$Page, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage($className$Page, mode, updatedAnswers))
+        }
+      )
+  }
+}

--- a/.g8/datePage/app/forms/$className$FormProvider.scala
+++ b/.g8/datePage/app/forms/$className$FormProvider.scala
@@ -1,0 +1,20 @@
+package forms
+
+import java.time.LocalDate
+
+import forms.mappings.Mappings
+import javax.inject.Inject
+import play.api.data.Form
+
+class $className$FormProvider @Inject() extends Mappings {
+
+  def apply(): Form[LocalDate] =
+    Form(
+      "value" -> localDate(
+        invalidKey     = "$className;format="decap"$.error.invalid",
+        allRequiredKey = "$className;format="decap"$.error.required.all",
+        twoRequiredKey = "$className;format="decap"$.error.required.two",
+        requiredKey    = "$className;format="decap"$.error.required"
+      )
+    )
+}

--- a/.g8/datePage/app/pages/$className$Page.scala
+++ b/.g8/datePage/app/pages/$className$Page.scala
@@ -1,0 +1,12 @@
+package pages
+
+import java.time.LocalDate
+
+import play.api.libs.json.JsPath
+
+case object $className$Page extends QuestionPage[LocalDate] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "$className;format="decap"$"
+}

--- a/.g8/datePage/app/views/$className$View.scala.html
+++ b/.g8/datePage/app/views/$className$View.scala.html
@@ -1,0 +1,28 @@
+@this(
+        main_template: MainTemplate,
+        formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode, afaId: AfaId)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"\${errorPrefix(form)} \${messages("$className;format="decap"$.title")}"
+) {
+
+    @formHelper(action = $className$Controller.onSubmit(mode, afaId), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("$className;format="decap"$.heading")
+
+        @components.input_date(
+            field = form("value"),
+            legend = messages("$className;format="decap"$.heading"),
+            legendClass = "visually-hidden"
+        )
+
+        @components.submit_button()
+    }
+}

--- a/.g8/datePage/app/views/$className$View.scala.html
+++ b/.g8/datePage/app/views/$className$View.scala.html
@@ -3,13 +3,13 @@
         formHelper: FormWithCSRF
 )
 
-@(form: Form[_], mode: Mode, afaId: AfaId)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = s"\${errorPrefix(form)} \${messages("$className;format="decap"$.title")}"
 ) {
 
-    @formHelper(action = $className$Controller.onSubmit(mode, afaId), 'autoComplete -> "off") {
+    @formHelper(action = $className$Controller.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.back_link()
 

--- a/.g8/datePage/default.properties
+++ b/.g8/datePage/default.properties
@@ -1,0 +1,2 @@
+description = Generates a controller and view for a page with a single date
+className = MyNewDatePage

--- a/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,7 +4,7 @@ import java.time.{LocalDate, ZoneOffset}
 
 import base.SpecBase
 import forms.$className$FormProvider
-import models.{AfaId ,NormalMode, UserAnswers}
+import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
@@ -24,15 +24,11 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
   val formProvider = new $className$FormProvider()
   val form = formProvider()
 
-  val afaId = AfaId("1")
-
   def onwardRoute = Call("GET", "/foo")
 
   val validAnswer = LocalDate.now(ZoneOffset.UTC)
 
-  lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(NormalMode, afaId).url
-
-  override val emptyUserAnswers = UserAnswers(afaId.value)
+  lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(NormalMode).url
 
   "$className$ Controller" must {
 
@@ -49,7 +45,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, NormalMode, afaId)(fakeRequest, messages).toString
+        view(form, NormalMode)(fakeRequest, messages).toString
 
       application.stop()
     }
@@ -69,7 +65,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), NormalMode, afaId)(fakeRequest, messages).toString
+        view(form.fill(validAnswer), NormalMode)(fakeRequest, messages).toString
 
       application.stop()
     }
@@ -122,7 +118,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, NormalMode, afaId)(fakeRequest, messages).toString
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
 
       application.stop()
     }

--- a/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
@@ -1,0 +1,165 @@
+package controllers
+
+import java.time.{LocalDate, ZoneOffset}
+
+import base.SpecBase
+import forms.$className$FormProvider
+import models.{AfaId ,NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import pages.$className$Page
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.$className$View
+
+import scala.concurrent.Future
+
+class $className$ControllerSpec extends SpecBase with MockitoSugar {
+
+  val formProvider = new $className$FormProvider()
+  val form = formProvider()
+
+  val afaId = AfaId("1")
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val validAnswer = LocalDate.now(ZoneOffset.UTC)
+
+  lazy val $className;format="decap"$Route = routes.$className$Controller.onPageLoad(NormalMode, afaId).url
+
+  override val emptyUserAnswers = UserAnswers(afaId.value)
+
+  "$className$ Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, $className;format="decap"$Route)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[$className$View]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode, afaId)(fakeRequest, messages).toString
+
+      application.stop()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set($className$Page, validAnswer).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, $className;format="decap"$Route)
+
+      val view = application.injector.instanceOf[$className$View]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(validAnswer), NormalMode, afaId)(fakeRequest, messages).toString
+
+      application.stop()
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      val request =
+        FakeRequest(POST, $className;format="decap"$Route)
+          .withFormUrlEncodedBody(
+            "value.day"   -> validAnswer.getDayOfMonth.toString,
+            "value.month" -> validAnswer.getMonthValue.toString,
+            "value.year"  -> validAnswer.getYear.toString
+          )
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, $className;format="decap"$Route)
+          .withFormUrlEncodedBody(("value", "invalid value"))
+
+      val boundForm = form.bind(Map("value" -> "invalid value"))
+
+      val view = application.injector.instanceOf[$className$View]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode, afaId)(fakeRequest, messages).toString
+
+      application.stop()
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, $className;format="decap"$Route)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, $className;format="decap"$Route)
+          .withFormUrlEncodedBody(
+            "value.day"   -> validAnswer.getDayOfMonth.toString,
+            "value.month" -> validAnswer.getMonthValue.toString,
+            "value.year"  -> validAnswer.getYear.toString
+          )
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
+    }
+  }
+}

--- a/.g8/datePage/generated-test/forms/$className$FormProviderSpec.scala
+++ b/.g8/datePage/generated-test/forms/$className$FormProviderSpec.scala
@@ -1,0 +1,23 @@
+package forms
+
+import java.time.{LocalDate, ZoneOffset}
+
+import forms.behaviours.DateBehaviours
+import play.api.data.FormError
+
+class $className$FormProviderSpec extends DateBehaviours {
+
+  val form = new $className$FormProvider()()
+
+  ".value" should {
+
+    val validData = datesBetween(
+      min = LocalDate.of(2000, 1, 1),
+      max = LocalDate.now(ZoneOffset.UTC)
+    )
+
+    behave like dateField(form, "value", validData)
+
+    behave like mandatoryDateField(form, "value", "$className;format="decap"$.error.required.all")
+  }
+}

--- a/.g8/datePage/generated-test/pages/$className$PageSpec.scala
+++ b/.g8/datePage/generated-test/pages/$className$PageSpec.scala
@@ -1,0 +1,22 @@
+package pages
+
+import java.time.LocalDate
+
+import org.scalacheck.Arbitrary
+import pages.behaviours.PageBehaviours
+
+class $className$PageSpec extends PageBehaviours {
+
+  "$className$Page" must {
+
+    implicit lazy val arbitraryLocalDate: Arbitrary[LocalDate] = Arbitrary {
+      datesBetween(LocalDate.of(1900, 1, 1), LocalDate.of(2100, 1, 1))
+    }
+
+    beRetrievable[LocalDate]($className$Page)
+
+    beSettable[LocalDate]($className$Page)
+
+    beRemovable[LocalDate]($className$Page)
+  }
+}

--- a/.g8/datePage/generated-test/views/$className$ViewSpec.scala
+++ b/.g8/datePage/generated-test/views/$className$ViewSpec.scala
@@ -13,13 +13,11 @@ class $className$ViewSpec extends QuestionViewBehaviours[LocalDate] {
 
   val messageKeyPrefix = "$className;format="decap"$"
 
-  val afaId = AfaId("1")
-
   val form = new $className$FormProvider()()
 
   "$className$View view" must {
 
-    val application = applicationBuilder(userAnswers = Some(UserAnswers(afaId.value))).build()
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
     val view = application.injector.instanceOf[$className$View]
 

--- a/.g8/datePage/generated-test/views/$className$ViewSpec.scala
+++ b/.g8/datePage/generated-test/views/$className$ViewSpec.scala
@@ -3,7 +3,7 @@ package views
 import java.time.LocalDate
 
 import forms.$className$FormProvider
-import models.{AfaId, NormalMode, UserAnswers}
+import models.{NormalMode, UserAnswers}
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.QuestionViewBehaviours
@@ -22,7 +22,7 @@ class $className$ViewSpec extends QuestionViewBehaviours[LocalDate] {
     val view = application.injector.instanceOf[$className$View]
 
     def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, NormalMode, afaId)(fakeRequest, messages)
+      view.apply(form, NormalMode)(fakeRequest, messages)
 
     behave like normalPage(applyView(form), messageKeyPrefix)
 

--- a/.g8/datePage/generated-test/views/$className$ViewSpec.scala
+++ b/.g8/datePage/generated-test/views/$className$ViewSpec.scala
@@ -1,0 +1,33 @@
+package views
+
+import java.time.LocalDate
+
+import forms.$className$FormProvider
+import models.{AfaId, NormalMode, UserAnswers}
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.QuestionViewBehaviours
+import views.html.$className$View
+
+class $className$ViewSpec extends QuestionViewBehaviours[LocalDate] {
+
+  val messageKeyPrefix = "$className;format="decap"$"
+
+  val afaId = AfaId("1")
+
+  val form = new $className$FormProvider()()
+
+  "$className$View view" must {
+
+    val application = applicationBuilder(userAnswers = Some(UserAnswers(afaId.value))).build()
+
+    val view = application.injector.instanceOf[$className$View]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode, afaId)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+  }
+}

--- a/.g8/datePage/migrations/$className__snake$.sh
+++ b/.g8/datePage/migrations/$className__snake$.sh
@@ -58,6 +58,7 @@ awk '/class/ {\
      print "      AnswerRow(";\
      print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
      print "        HtmlFormat.escape(x.format(dateFormatter)),";\
+     print "        "false\",";\
      print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
      print "      )";\
      print "  }";\

--- a/.g8/datePage/migrations/$className__snake$.sh
+++ b/.g8/datePage/migrations/$className__snake$.sh
@@ -58,8 +58,8 @@ awk '/class/ {\
      print "      AnswerRow(";\
      print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
      print "        HtmlFormat.escape(x.format(dateFormatter)),";\
-     print "        "false\",";\
      print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
+     print "      )";\
      print "      )";\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala

--- a/.g8/datePage/migrations/$className__snake$.sh
+++ b/.g8/datePage/migrations/$className__snake$.sh
@@ -60,7 +60,6 @@ awk '/class/ {\
      print "        HtmlFormat.escape(x.format(dateFormatter)),";\
      print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
      print "      )";\
-     print "      )";\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 

--- a/.g8/datePage/migrations/$className__snake$.sh
+++ b/.g8/datePage/migrations/$className__snake$.sh
@@ -6,11 +6,11 @@ echo "Applying migration $className;format="snake"$"
 echo "Adding routes to conf/app.routes"
 
 echo "" >> ../conf/app.routes
-echo "GET        /:afaId/$className;format="decap"$                  controllers.$className$Controller.onPageLoad(mode: Mode = NormalMode, afaId: AfaId)" >> ../conf/app.routes
-echo "POST       /:afaId/$className;format="decap"$                  controllers.$className$Controller.onSubmit(mode: Mode = NormalMode, afaId: AfaId)" >> ../conf/app.routes
+echo "GET        /$className;format="decap"$                  controllers.$className$Controller.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /$className;format="decap"$                  controllers.$className$Controller.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
 
-echo "GET        /:afaId/change$className$                        controllers.$className$Controller.onPageLoad(mode: Mode = CheckMode, afaId: AfaId)" >> ../conf/app.routes
-echo "POST       /:afaId/change$className$                        controllers.$className$Controller.onSubmit(mode: Mode = CheckMode, afaId: AfaId)" >> ../conf/app.routes
+echo "GET        /change$className$                        controllers.$className$Controller.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /change$className$                        controllers.$className$Controller.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
 
 echo "Adding messages to conf.messages"
 echo "" >> ../conf/messages.en
@@ -58,7 +58,7 @@ awk '/class/ {\
      print "      AnswerRow(";\
      print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
      print "        HtmlFormat.escape(x.format(dateFormatter)),";\
-     print "        routes.$className$Controller.onPageLoad(CheckMode, afaId).url";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
      print "      )";\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala

--- a/.g8/datePage/migrations/$className__snake$.sh
+++ b/.g8/datePage/migrations/$className__snake$.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration $className;format="snake"$"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /:afaId/$className;format="decap"$                  controllers.$className$Controller.onPageLoad(mode: Mode = NormalMode, afaId: AfaId)" >> ../conf/app.routes
+echo "POST       /:afaId/$className;format="decap"$                  controllers.$className$Controller.onSubmit(mode: Mode = NormalMode, afaId: AfaId)" >> ../conf/app.routes
+
+echo "GET        /:afaId/change$className$                        controllers.$className$Controller.onPageLoad(mode: Mode = CheckMode, afaId: AfaId)" >> ../conf/app.routes
+echo "POST       /:afaId/change$className$                        controllers.$className$Controller.onSubmit(mode: Mode = CheckMode, afaId: AfaId)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "$className;format="decap"$.title = $className$" >> ../conf/messages.en
+echo "$className;format="decap"$.heading = $className$" >> ../conf/messages.en
+echo "$className;format="decap"$.checkYourAnswersLabel = $className$" >> ../conf/messages.en
+echo "$className;format="decap"$.error.required.all = Enter the $className;format="decap"$" >> ../conf/messages.en
+echo "$className;format="decap"$.error.required.two = The $className;format="decap"$" must include {0} and {1} >> ../conf/messages.en
+echo "$className;format="decap"$.error.required = The $className;format="decap"$ must include {0}" >> ../conf/messages.en
+echo "$className;format="decap"$.error.invalid = Enter a real $className$" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitrary$className$UserAnswersEntry: Arbitrary[($className$Page.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[$className$Page.type]";\
+    print "        value <- arbitrary[Int].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitrary$className$Page: Arbitrary[$className$Page.type] =";\
+    print "    Arbitrary($className$Page)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[($className$Page.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.get($className$Page) map {";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
+     print "        HtmlFormat.escape(x.format(dateFormatter)),";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode, afaId).url";\
+     print "      )";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration $className;format="snake"$ completed"

--- a/.g8/intPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/intPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -39,6 +39,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -57,6 +59,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(validAnswer), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -75,6 +79,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -95,6 +101,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -107,6 +115,8 @@ class $className$ControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -122,6 +132,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/.g8/intPage/migrations/$className__snake$.sh
+++ b/.g8/intPage/migrations/$className__snake$.sh
@@ -54,8 +54,13 @@ awk '/class/ {\
      print;\
      print "";\
      print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.get($className$Page) map {";\
-     print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", s\"\$x\", false, routes.$className$Controller.onPageLoad(CheckMode).url)";\
-     print "  }";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
+     print "        HtmlFormat.escape(x.toString),";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
+     print "      )";\
+     print "  }";\	     print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
 echo "Migration $className;format="snake"$ completed"

--- a/.g8/optionsPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/optionsPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -37,6 +37,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -55,6 +57,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill($className$.values.head), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -73,6 +77,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -93,6 +99,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -105,6 +113,8 @@ class $className$ControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -120,6 +130,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/.g8/optionsPage/migrations/$className__snake$.sh
+++ b/.g8/optionsPage/migrations/$className__snake$.sh
@@ -63,7 +63,12 @@ awk '/class/ {\
      print;\
      print "";\
      print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.get($className$Page) map {";\
-     print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", s\"$className;format="decap"$.\$x\", true, routes.$className$Controller.onPageLoad(CheckMode).url)";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
+     print "        HtmlFormat.escape(messages(s\"$className;format="decap"$.\$x\")),";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
+     print "      )";\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 

--- a/.g8/page/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/page/generated-test/controllers/$className$ControllerSpec.scala
@@ -23,6 +23,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view()(fakeRequest, messages).toString
+
+      application.stop()
     }
   }
 }

--- a/.g8/questionPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/questionPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -47,6 +47,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(request, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -63,6 +65,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill($className$("value 1", "value 2")), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -81,6 +85,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -101,6 +107,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -113,6 +121,8 @@ class $className$ControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -128,6 +138,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/.g8/questionPage/migrations/$className__snake$.sh
+++ b/.g8/questionPage/migrations/$className__snake$.sh
@@ -69,7 +69,12 @@ awk '/class/ {\
      print;\
      print "";\
      print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.get($className$Page) map {";\
-     print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", s\"\${x.field1} \${x.field2}\", false, routes.$className$Controller.onPageLoad(CheckMode).url)";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
+     print "        HtmlFormat.escape(s\"\${x.field1} \${x.field2}\"),";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
+     print "      )";\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 

--- a/.g8/stringPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/stringPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -37,6 +37,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -55,6 +57,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -72,6 +76,8 @@ class $className$ControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -92,6 +98,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -105,6 +113,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -120,6 +130,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/.g8/stringPage/migrations/$className__snake$.sh
+++ b/.g8/stringPage/migrations/$className__snake$.sh
@@ -52,7 +52,12 @@ awk '/class/ {\
      print;\
      print "";\
      print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.get($className$Page) map {";\
-     print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", s\"\$x\", false, routes.$className$Controller.onPageLoad(CheckMode).url)";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
+     print "        HtmlFormat.escape(x),";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
+     print "      )";\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 

--- a/.g8/yesNoPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/yesNoPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -37,6 +37,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -55,6 +57,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -73,6 +77,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -93,6 +99,8 @@ class $className$ControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -106,6 +114,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -121,6 +131,8 @@ class $className$ControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/.g8/yesNoPage/migrations/$className__snake$.sh
+++ b/.g8/yesNoPage/migrations/$className__snake$.sh
@@ -51,7 +51,13 @@ awk '/class/ {\
      print;\
      print "";\
      print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.get($className$Page) map {";\
-     print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.$className$Controller.onPageLoad(CheckMode).url)"; print "  }";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"$className;format="decap"$.checkYourAnswersLabel\",";\
+     print "        yesOrNo(x),";\
+     print "        routes.$className$Controller.onPageLoad(CheckMode).url";\
+     print "      )";\
+     print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
 echo "Migration $className;format="snake"$ completed"

--- a/app/controllers/AdministrationOutsideUKController.scala
+++ b/app/controllers/AdministrationOutsideUKController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._

--- a/app/controllers/AdministrationOutsideUKController.scala
+++ b/app/controllers/AdministrationOutsideUKController.scala
@@ -1,0 +1,58 @@
+package controllers
+
+import controllers.actions._
+import forms.AdministrationOutsideUKFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.AdministrationOutsideUKPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.AdministrationOutsideUKView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AdministrationOutsideUKController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: AdministrationOutsideUKFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: AdministrationOutsideUKView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(AdministrationOutsideUKPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(AdministrationOutsideUKPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(AdministrationOutsideUKPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/AgentOtherThanBarristerController.scala
+++ b/app/controllers/AgentOtherThanBarristerController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.AgentOtherThanBarristerFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.AgentOtherThanBarristerPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.AgentOtherThanBarristerView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AgentOtherThanBarristerController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: AgentOtherThanBarristerFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: AgentOtherThanBarristerView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(AgentOtherThanBarristerPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(AgentOtherThanBarristerPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(AgentOtherThanBarristerPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/CountryAdministeringTrustController.scala
+++ b/app/controllers/CountryAdministeringTrustController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.CountryAdministeringTrustFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.CountryAdministeringTrustPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.CountryAdministeringTrustView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CountryAdministeringTrustController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: CountryAdministeringTrustFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: CountryAdministeringTrustView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(CountryAdministeringTrustPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(CountryAdministeringTrustPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(CountryAdministeringTrustPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/CountryGoverningTrustController.scala
+++ b/app/controllers/CountryGoverningTrustController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._

--- a/app/controllers/CountryGoverningTrustController.scala
+++ b/app/controllers/CountryGoverningTrustController.scala
@@ -1,0 +1,58 @@
+package controllers
+
+import controllers.actions._
+import forms.CountryGoverningTrustFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.CountryGoverningTrustPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.CountryGoverningTrustView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CountryGoverningTrustController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: CountryGoverningTrustFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: CountryGoverningTrustView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(CountryGoverningTrustPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(CountryGoverningTrustPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(CountryGoverningTrustPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/EstablishedUnderScotsLawController.scala
+++ b/app/controllers/EstablishedUnderScotsLawController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.EstablishedUnderScotsLawFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.EstablishedUnderScotsLawPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.EstablishedUnderScotsLawView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class EstablishedUnderScotsLawController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: EstablishedUnderScotsLawFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: EstablishedUnderScotsLawView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(EstablishedUnderScotsLawPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(EstablishedUnderScotsLawPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(EstablishedUnderScotsLawPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/GovernedOutsideTheUKController.scala
+++ b/app/controllers/GovernedOutsideTheUKController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.GovernedOutsideTheUKFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.GovernedOutsideTheUKPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.GovernedOutsideTheUKView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GovernedOutsideTheUKController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: GovernedOutsideTheUKFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: GovernedOutsideTheUKView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(GovernedOutsideTheUKPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(GovernedOutsideTheUKPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(GovernedOutsideTheUKPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/InheritanceTaxActController.scala
+++ b/app/controllers/InheritanceTaxActController.scala
@@ -17,38 +17,38 @@
 package controllers
 
 import controllers.actions._
-import forms.TrustPreviouslyResidentFormProvider
+import forms.InheritanceTaxActFormProvider
 import javax.inject.Inject
-import models.Mode
+import models.{Mode, UserAnswers}
 import navigation.Navigator
-import pages.TrustPreviouslyResidentPage
+import pages.InheritanceTaxActPage
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
-import views.html.TrustPreviouslyResidentView
+import views.html.InheritanceTaxActView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class TrustPreviouslyResidentController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: TrustPreviouslyResidentFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: TrustPreviouslyResidentView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class InheritanceTaxActController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: InheritanceTaxActFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: InheritanceTaxActView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
-  val form = formProvider()
+  val form: Form[Boolean] = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(TrustPreviouslyResidentPage) match {
+      val preparedForm = request.userAnswers.get(InheritanceTaxActPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
@@ -56,7 +56,7 @@ class TrustPreviouslyResidentController @Inject()(
       Ok(view(preparedForm, mode))
   }
 
-  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
     implicit request =>
 
       form.bindFromRequest().fold(
@@ -65,9 +65,9 @@ class TrustPreviouslyResidentController @Inject()(
 
         value => {
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustPreviouslyResidentPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(InheritanceTaxActPage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(TrustPreviouslyResidentPage, mode)(updatedAnswers))
+          } yield Redirect(navigator.nextPage(InheritanceTaxActPage, mode)(updatedAnswers))
         }
       )
   }

--- a/app/controllers/NonResidentTypeController.scala
+++ b/app/controllers/NonResidentTypeController.scala
@@ -17,38 +17,38 @@
 package controllers
 
 import controllers.actions._
-import forms.TrustPreviouslyResidentFormProvider
+import forms.NonResidentTypeFormProvider
 import javax.inject.Inject
-import models.Mode
+import models.{Enumerable, Mode}
 import navigation.Navigator
-import pages.TrustPreviouslyResidentPage
+import pages.NonResidentTypePage
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
-import views.html.TrustPreviouslyResidentView
+import views.html.NonResidentTypeView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class TrustPreviouslyResidentController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: TrustPreviouslyResidentFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: TrustPreviouslyResidentView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class NonResidentTypeController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       sessionRepository: SessionRepository,
+                                       navigator: Navigator,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       formProvider: NonResidentTypeFormProvider,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: NonResidentTypeView
+                                     )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Enumerable.Implicits {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(TrustPreviouslyResidentPage) match {
+      val preparedForm = request.userAnswers.get(NonResidentTypePage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
@@ -65,9 +65,9 @@ class TrustPreviouslyResidentController @Inject()(
 
         value => {
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustPreviouslyResidentPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(NonResidentTypePage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(TrustPreviouslyResidentPage, mode)(updatedAnswers))
+          } yield Redirect(navigator.nextPage(NonResidentTypePage, mode)(updatedAnswers))
         }
       )
   }

--- a/app/controllers/RegisteringTrustFor5AController.scala
+++ b/app/controllers/RegisteringTrustFor5AController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.RegisteringTrustFor5AFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.RegisteringTrustFor5APage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.RegisteringTrustFor5AView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class RegisteringTrustFor5AController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: RegisteringTrustFor5AFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: RegisteringTrustFor5AView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(RegisteringTrustFor5APage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(RegisteringTrustFor5APage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(RegisteringTrustFor5APage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/TrustNameController.scala
+++ b/app/controllers/TrustNameController.scala
@@ -37,7 +37,6 @@ class TrustNameController @Inject()(
                                         navigator: Navigator,
                                         identify: IdentifierAction,
                                         getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
                                         formProvider: TrustNameFormProvider,
                                         val controllerComponents: MessagesControllerComponents,
                                         view: TrustNameView

--- a/app/controllers/TrustNameController.scala
+++ b/app/controllers/TrustNameController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.TrustNameFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.TrustNamePage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.TrustNameView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TrustNameController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: TrustNameFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: TrustNameView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData ) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.getOrElse(UserAnswers(request.internalId)).get(TrustNamePage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.getOrElse(UserAnswers(request.internalId)).set(TrustNamePage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(TrustNamePage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/TrustPreviouslyResidentController.scala
+++ b/app/controllers/TrustPreviouslyResidentController.scala
@@ -1,0 +1,58 @@
+package controllers
+
+import controllers.actions._
+import forms.TrustPreviouslyResidentFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.TrustPreviouslyResidentPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.TrustPreviouslyResidentView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TrustPreviouslyResidentController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: TrustPreviouslyResidentFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: TrustPreviouslyResidentView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(TrustPreviouslyResidentPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustPreviouslyResidentPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(TrustPreviouslyResidentPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/TrustResidentInUKController.scala
+++ b/app/controllers/TrustResidentInUKController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.TrustResidentInUKFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.TrustResidentInUKPage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.TrustResidentInUKView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TrustResidentInUKController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: TrustResidentInUKFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: TrustResidentInUKView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(TrustResidentInUKPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustResidentInUKPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(TrustResidentInUKPage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/TrustResidentOffshoreController.scala
+++ b/app/controllers/TrustResidentOffshoreController.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import forms.TrustResidentOffshoreFormProvider
+import javax.inject.Inject
+import models.{Mode, UserAnswers}
+import navigation.Navigator
+import pages.TrustResidentOffshorePage
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import views.html.TrustResidentOffshoreView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TrustResidentOffshoreController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: TrustResidentOffshoreFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: TrustResidentOffshoreView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form: Form[Boolean] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(TrustResidentOffshorePage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value => {
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustResidentOffshorePage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(TrustResidentOffshorePage, mode)(updatedAnswers))
+        }
+      )
+  }
+}

--- a/app/controllers/WhenTrustSetupController.scala
+++ b/app/controllers/WhenTrustSetupController.scala
@@ -1,30 +1,46 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
-import forms.$className$FormProvider
+import forms.WhenTrustSetupFormProvider
 import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
-import pages.$className$Page
+import pages.WhenTrustSetupPage
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
-import views.html.$className$View
+import views.html.WhenTrustSetupView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class $className$Controller @Inject()(
+class WhenTrustSetupController @Inject()(
                                                   override val messagesApi: MessagesApi,
                                                   sessionRepository: SessionRepository,
                                                   navigator: Navigator,
                                                   identify: IdentifierAction,
                                                   getData: DataRetrievalAction,
                                                   requireData: DataRequiredAction,
-                                                  formProvider: $className$FormProvider,
+                                                  formProvider: WhenTrustSetupFormProvider,
                                                   val controllerComponents: MessagesControllerComponents,
-                                                  view: $className$View
+                                                  view: WhenTrustSetupView
                                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
@@ -32,7 +48,7 @@ class $className$Controller @Inject()(
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get($className$Page) match {
+      val preparedForm = request.userAnswers.get(WhenTrustSetupPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
@@ -49,10 +65,11 @@ class $className$Controller @Inject()(
 
         value => {
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set($className$Page, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(WhenTrustSetupPage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage($className$Page, mode)(updatedAnswers))
+          } yield Redirect(navigator.nextPage(WhenTrustSetupPage, mode)(updatedAnswers))
         }
       )
   }
 }
+

--- a/app/forms/AdministrationOutsideUKFormProvider.scala
+++ b/app/forms/AdministrationOutsideUKFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject

--- a/app/forms/AdministrationOutsideUKFormProvider.scala
+++ b/app/forms/AdministrationOutsideUKFormProvider.scala
@@ -1,0 +1,14 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class AdministrationOutsideUKFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("administrationOutsideUK.error.required")
+    )
+}

--- a/app/forms/AgentOtherThanBarristerFormProvider.scala
+++ b/app/forms/AgentOtherThanBarristerFormProvider.scala
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package generators
+package forms
 
-import models._
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.{Arbitrary, Gen}
+import javax.inject.Inject
 
-trait ModelGenerators {
+import forms.mappings.Mappings
+import play.api.data.Form
 
-  implicit lazy val arbitraryNonResidentType: Arbitrary[NonResidentType] =
-    Arbitrary {
-      Gen.oneOf(NonResidentType.values.toSeq)
-    }
+class AgentOtherThanBarristerFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("agentOtherThanBarrister.error.required")
+    )
 }

--- a/app/forms/CountryAdministeringTrustFormProvider.scala
+++ b/app/forms/CountryAdministeringTrustFormProvider.scala
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-package pages
+package forms
 
-import pages.behaviours.PageBehaviours
+import javax.inject.Inject
 
+import forms.mappings.Mappings
+import play.api.data.Form
 
-class TrustNamePageSpec extends PageBehaviours {
+class CountryAdministeringTrustFormProvider @Inject() extends Mappings {
 
-  "TrustNamePage" must {
-
-    beRetrievable[String](TrustNamePage)
-
-    beSettable[String](TrustNamePage)
-
-    beRemovable[String](TrustNamePage)
-  }
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("countryAdministeringTrust.error.required")
+        .verifying(maxLength(100, "countryAdministeringTrust.error.length"))
+    )
 }

--- a/app/forms/CountryGoverningTrustFormProvider.scala
+++ b/app/forms/CountryGoverningTrustFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject

--- a/app/forms/CountryGoverningTrustFormProvider.scala
+++ b/app/forms/CountryGoverningTrustFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class CountryGoverningTrustFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("countryGoverningTrust.error.required")
+        .verifying(maxLength(100, "countryGoverningTrust.error.length"))
+    )
+}

--- a/app/forms/EstablishedUnderScotsLawFormProvider.scala
+++ b/app/forms/EstablishedUnderScotsLawFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class EstablishedUnderScotsLawFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("establishedUnderScotsLaw.error.required")
+    )
+}

--- a/app/forms/GovernedOutsideTheUKFormProvider.scala
+++ b/app/forms/GovernedOutsideTheUKFormProvider.scala
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package generators
+package forms
 
-import org.scalacheck.Arbitrary
-import pages._
+import javax.inject.Inject
 
-trait PageGenerators {
+import forms.mappings.Mappings
+import play.api.data.Form
 
-  implicit lazy val arbitraryGovernedOutsideTheUKPage: Arbitrary[GovernedOutsideTheUKPage.type] =
-    Arbitrary(GovernedOutsideTheUKPage)
+class GovernedOutsideTheUKFormProvider @Inject() extends Mappings {
 
-  implicit lazy val arbitraryTrustNamePage: Arbitrary[TrustNamePage.type] =
-    Arbitrary(TrustNamePage)
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("governedOutsideTheUK.error.required")
+    )
 }

--- a/app/forms/InheritanceTaxActFormProvider.scala
+++ b/app/forms/InheritanceTaxActFormProvider.scala
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-package pages
+package forms
 
-import play.api.libs.json.JsPath
+import javax.inject.Inject
 
-case object TrustPreviouslyResidentPage extends QuestionPage[String] {
+import forms.mappings.Mappings
+import play.api.data.Form
 
-  override def path: JsPath = JsPath \ toString
+class InheritanceTaxActFormProvider @Inject() extends Mappings {
 
-  override def toString: String = "trustPreviouslyResident"
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("inheritanceTaxAct.error.required")
+    )
 }

--- a/app/forms/NonResidentTypeFormProvider.scala
+++ b/app/forms/NonResidentTypeFormProvider.scala
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-package pages
+package forms
 
-import play.api.libs.json.JsPath
+import javax.inject.Inject
 
-case object TrustPreviouslyResidentPage extends QuestionPage[String] {
+import forms.mappings.Mappings
+import play.api.data.Form
+import models.NonResidentType
 
-  override def path: JsPath = JsPath \ toString
+class NonResidentTypeFormProvider @Inject() extends Mappings {
 
-  override def toString: String = "trustPreviouslyResident"
+  def apply(): Form[NonResidentType] =
+    Form(
+      "value" -> enumerable[NonResidentType]("non-residentType.error.required")
+    )
 }

--- a/app/forms/RegisteringTrustFor5AFormProvider.scala
+++ b/app/forms/RegisteringTrustFor5AFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class RegisteringTrustFor5AFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("registeringTrustFor5A.error.required")
+    )
+}

--- a/app/forms/TrustNameFormProvider.scala
+++ b/app/forms/TrustNameFormProvider.scala
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package utils
+package forms
 
-import controllers.routes
-import models.{CheckMode, UserAnswers}
-import pages._
-import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
+import javax.inject.Inject
 
-class CheckYourAnswersHelper(userAnswers: UserAnswers) {
+import forms.mappings.Mappings
+import play.api.data.Form
 
-  def trustName: Option[AnswerRow] = userAnswers.get(TrustNamePage) map {
-    x => AnswerRow("trustName.checkYourAnswersLabel", s"$x", false, routes.TrustNameController.onPageLoad(CheckMode).url)
-  }
+class TrustNameFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("trustName.error.required")
+        .verifying(maxLength(53, "trustName.error.length"))
+    )
 }

--- a/app/forms/TrustPreviouslyResidentFormProvider.scala
+++ b/app/forms/TrustPreviouslyResidentFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject

--- a/app/forms/TrustPreviouslyResidentFormProvider.scala
+++ b/app/forms/TrustPreviouslyResidentFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class TrustPreviouslyResidentFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("trustPreviouslyResident.error.required")
+        .verifying(maxLength(100, "trustPreviouslyResident.error.length"))
+    )
+}

--- a/app/forms/TrustResidentInUKFormProvider.scala
+++ b/app/forms/TrustResidentInUKFormProvider.scala
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package pages
+package forms
 
-import pages.behaviours.PageBehaviours
+import javax.inject.Inject
 
+import forms.mappings.Mappings
+import play.api.data.Form
 
-class TrustNamePageSpec extends PageBehaviours {
+class TrustResidentInUKFormProvider @Inject() extends Mappings {
 
-  "TrustNamePage" must {
-
-    beRetrievable[String](TrustNamePage)
-
-    beSettable[String](TrustNamePage)
-
-    beRemovable[String](TrustNamePage)
-  }
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("trustResidentInUK.error.required")
+    )
 }

--- a/app/forms/TrustResidentOffshoreFormProvider.scala
+++ b/app/forms/TrustResidentOffshoreFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class TrustResidentOffshoreFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("trustResidentOffshore.error.required")
+    )
+}

--- a/app/forms/WhenTrustSetupFormProvider.scala
+++ b/app/forms/WhenTrustSetupFormProvider.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +12,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import viewmodels.AnswerRow
+package forms
 
-@(row: AnswerRow)(implicit messages: Messages)
+import java.time.LocalDate
 
-<li>
-    <div class="cya-question">@messages(row.label)</div>
-    <div class="cya-answer">
-        @row.answer
-    </div>
-    <div class="cya-change">
-        <a href='@row.changeUrl'>
-            <span aria-hidden="true">@messages("site.edit")</span>
-            <span class="visually-hidden">@messages("site.hidden-edit", messages(row.label))</span>
-        </a>
-    </div>
-</li>
+import forms.mappings.Mappings
+import javax.inject.Inject
+import play.api.data.Form
+
+class WhenTrustSetupFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[LocalDate] =
+    Form(
+      "value" -> localDate(
+        invalidKey     = "whenTrustSetup.error.invalid",
+        allRequiredKey = "whenTrustSetup.error.required.all",
+        twoRequiredKey = "whenTrustSetup.error.required.two",
+        requiredKey    = "whenTrustSetup.error.required"
+      )
+    )
+}

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -100,6 +100,7 @@ trait Constraints {
       case _ =>
         Valid
     }
+
   protected def minDate(minimum: LocalDate, errorKey: String, args: Any*): Constraint[LocalDate] =
     Constraint {
       case date if date.isBefore(minimum) =>
@@ -107,4 +108,5 @@ trait Constraints {
       case _ =>
         Valid
     }
+
 }

--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import java.time.LocalDate
+
+import play.api.data.FormError
+import play.api.data.format.Formatter
+
+import scala.util.{Failure, Success, Try}
+
+private[mappings] class LocalDateFormatter(
+                                            invalidKey: String,
+                                            allRequiredKey: String,
+                                            twoRequiredKey: String,
+                                            requiredKey: String
+                                          ) extends Formatter[LocalDate] with Formatters {
+
+  private val fieldKeys: List[String] = List("day", "month", "year")
+
+  private def toDate(key: String, day: Int, month: Int, year: Int): Either[Seq[FormError], LocalDate] =
+    Try(LocalDate.of(year, month, day)) match {
+      case Success(date) =>
+        Right(date)
+      case Failure(_) =>
+        Left(Seq(FormError(key, invalidKey, fieldKeys)))
+    }
+
+  private def formatDate(key: String, data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+
+    val int = intFormatter(
+      requiredKey = invalidKey,
+      wholeNumberKey = invalidKey,
+      nonNumericKey = invalidKey
+    )
+
+    for {
+      day   <- int.bind(s"$key.day", data).right
+      month <- int.bind(s"$key.month", data).right
+      year  <- int.bind(s"$key.year", data).right
+      date  <- toDate(key, day, month, year).right
+    } yield date
+  }
+
+  override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+
+    val fields = fieldKeys.map {
+      field =>
+        field -> data.get(s"$key.$field").filter(_.nonEmpty)
+    }.toMap
+
+    lazy val missingFields = fields
+      .withFilter(_._2.isEmpty)
+      .map(_._1)
+      .toList
+
+    fields.count(_._2.isDefined) match {
+      case 3 =>
+        formatDate(key, data).left.map {
+          _.map(_.copy(key = key, args = fieldKeys))
+        }
+      case 2 =>
+        Left(List(FormError(key, requiredKey, missingFields)))
+      case 1 =>
+        Left(List(FormError(key, twoRequiredKey, missingFields)))
+      case _ =>
+        Left(List(FormError(key, allRequiredKey, missingFields)))
+    }
+  }
+
+  override def unbind(key: String, value: LocalDate): Map[String, String] =
+    Map(
+      s"$key.day" -> value.getDayOfMonth.toString,
+      s"$key.month" -> value.getMonthValue.toString,
+      s"$key.year" -> value.getYear.toString
+    )
+}

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -16,6 +16,8 @@
 
 package forms.mappings
 
+import java.time.LocalDate
+
 import play.api.data.FieldMapping
 import play.api.data.Forms.of
 import models.Enumerable
@@ -38,4 +40,11 @@ trait Mappings extends Formatters with Constraints {
   protected def enumerable[A](requiredKey: String = "error.required",
                               invalidKey: String = "error.invalid")(implicit ev: Enumerable[A]): FieldMapping[A] =
     of(enumerableFormatter[A](requiredKey, invalidKey))
+
+  protected def localDate(
+                           invalidKey: String,
+                           allRequiredKey: String,
+                           twoRequiredKey: String,
+                           requiredKey: String): FieldMapping[LocalDate] =
+    of(new LocalDateFormatter(invalidKey, allRequiredKey, twoRequiredKey, requiredKey))
 }

--- a/app/models/NonResidentType.scala
+++ b/app/models/NonResidentType.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json._
+import viewmodels.RadioOption
+
+sealed trait NonResidentType
+
+object NonResidentType extends Enumerable.Implicits {
+
+  case object 1 extends WithName("1") with NonResidentType
+  case object 2 extends WithName("2") with NonResidentType
+  case object 3 extends WithName("3") with NonResidentType
+
+  val values: Set[NonResidentType] = Set(
+    1, 2, 3
+  )
+
+  val options: Set[RadioOption] = values.map {
+    value =>
+      RadioOption("nonresidentType", value.toString)
+  }
+
+  implicit val enumerable: Enumerable[NonResidentType] =
+    Enumerable(values.toSeq.map(v => v.toString -> v): _*)
+}

--- a/app/models/NonResidentType.scala
+++ b/app/models/NonResidentType.scala
@@ -23,12 +23,12 @@ sealed trait NonResidentType
 
 object NonResidentType extends Enumerable.Implicits {
 
-  case object 1 extends WithName("1") with NonResidentType
-  case object 2 extends WithName("2") with NonResidentType
-  case object 3 extends WithName("3") with NonResidentType
+  case object resident extends WithName("resident") with NonResidentType
+  case object nonresident extends WithName("nonresident") with NonResidentType
+  case object ceaseresident extends WithName("ceaseresident") with NonResidentType
 
   val values: Set[NonResidentType] = Set(
-    1, 2, 3
+    resident, nonresident, ceaseresident
   )
 
   val options: Set[RadioOption] = values.map {

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -29,7 +29,9 @@ class Navigator @Inject()() {
   private val routeMap: Map[Page, UserAnswers => Call] = Map(
     TrustNamePage -> (_ => routes.GovernedOutsideTheUKController.onPageLoad(NormalMode)),
     GovernedOutsideTheUKPage -> GovernedOutsideTheUKRoute(),
-    CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)))
+    CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)),
+    AdministrationOutsideUKPage -> AdministrationOutsideUKRoute(),
+    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)))
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 
@@ -47,4 +49,11 @@ class Navigator @Inject()() {
     case Some(false) => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)
     case None =>routes.IndexController.onPageLoad()
   }
+
+  private def AdministrationOutsideUKRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
+    case Some(true) => routes.CountryAdministeringTrustController.onPageLoad(NormalMode)
+    case Some(false) => routes.TrustResidentInUKController.onPageLoad(NormalMode)
+    case None =>routes.IndexController.onPageLoad()
+  }
+
 }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -34,6 +34,7 @@ class Navigator @Inject()() {
     TrustResidentInUKPage -> TrustResidentinUKRoute(),
     EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)),
     TrustResidentOffshorePage -> TrustResidentOffshoreRoute(),
+    TrustPreviouslyResidentPage -> (_ => routes.IndexController.onPageLoad()),
     RegisteringTrustFor5APage -> RegisteringTrustFor5ARoute(),
     NonResidentTypePage -> (_ => routes.IndexController.onPageLoad()),
     InheritanceTaxActPage -> (_ => routes.IndexController.onPageLoad())

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -26,21 +26,25 @@ import models._
 class Navigator @Inject()() {
 
   private val routeMap: Map[Page, UserAnswers => Call] = Map(
-    TrustNamePage -> (_ => routes.GovernedOutsideTheUKController.onPageLoad(NormalMode)),
-    GovernedOutsideTheUKPage -> GovernedOutsideTheUKRoute(),
+    TrustNamePage -> (_ => routes.WhenTrustSetupController.onPageLoad(NormalMode)),
+    WhenTrustSetupPage -> (_ => routes.GovernedOutsideTheUKController.onPageLoad(NormalMode)),
+    GovernedOutsideTheUKPage -> isTrustGovernedOutsideUK,
     CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)),
-    AdministrationOutsideUKPage -> AdministrationOutsideUKRoute(),
-    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)),
-    TrustResidentInUKPage -> TrustResidentinUKRoute(),
-    EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)),
-    TrustResidentOffshorePage -> TrustResidentOffshoreRoute(),
-    TrustPreviouslyResidentPage -> (_ => routes.IndexController.onPageLoad()),
-    RegisteringTrustFor5APage -> RegisteringTrustFor5ARoute(),
-    NonResidentTypePage -> (_ => routes.IndexController.onPageLoad()),
-    InheritanceTaxActPage -> InheritanceTaxActRoute(),
-    AgentOtherThanBarristerPage -> (_ => routes.IndexController.onPageLoad())
+    AdministrationOutsideUKPage -> isTrustGeneralAdministration,
+    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode))
   )
 
+  private def isTrustGovernedOutsideUK(answers: UserAnswers) = answers.get(GovernedOutsideTheUKPage) match {
+    case Some(true)  => routes.CountryGoverningTrustController.onPageLoad(NormalMode)
+    case Some(false) => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)
+    case None        => routes.SessionExpiredController.onPageLoad()
+  }
+
+  private def isTrustGeneralAdministration(answers: UserAnswers) = answers.get(AdministrationOutsideUKPage) match {
+    case Some(true)  => routes.CountryAdministeringTrustController.onPageLoad(NormalMode)
+    case Some(false) => routes.TrustResidentInUKController.onPageLoad(NormalMode)
+    case None        => routes.SessionExpiredController.onPageLoad()
+  }
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 
@@ -52,41 +56,4 @@ class Navigator @Inject()() {
     case CheckMode =>
       checkRouteMap.getOrElse(page, _ => routes.CheckYourAnswersController.onPageLoad())
   }
-
-  private def GovernedOutsideTheUKRoute()(answers: UserAnswers ) = answers.get(GovernedOutsideTheUKPage) match {
-    case Some(true) => routes.CountryGoverningTrustController.onPageLoad(NormalMode)
-    case Some(false) => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)
-    case None =>routes.IndexController.onPageLoad()
-  }
-
-  private def AdministrationOutsideUKRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
-    case Some(true) => routes.CountryAdministeringTrustController.onPageLoad(NormalMode)
-    case Some(false) => routes.TrustResidentInUKController.onPageLoad(NormalMode)
-    case None =>routes.IndexController.onPageLoad()
-  }
-
-  private def TrustResidentinUKRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
-    case Some(true) => routes.EstablishedUnderScotsLawController.onPageLoad(NormalMode)
-    case Some(false) => routes.RegisteringTrustFor5AController.onPageLoad(NormalMode)
-    case None =>routes.IndexController.onPageLoad()
-  }
-
-  private def TrustResidentOffshoreRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
-    case Some(true) => routes.TrustPreviouslyResidentController.onPageLoad(NormalMode)
-    case Some(false) => routes.IndexController.onPageLoad()
-    case None =>routes.IndexController.onPageLoad()
-  }
-
-  private def RegisteringTrustFor5ARoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
-    case Some(true) => routes.NonResidentTypeController.onPageLoad(NormalMode)
-    case Some(false) => routes.InheritanceTaxActController.onPageLoad(NormalMode)
-    case None =>routes.IndexController.onPageLoad()
-  }
-
-  private def InheritanceTaxActRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
-    case Some(true) => routes.AgentOtherThanBarristerController.onPageLoad(NormalMode)
-    case Some(false) => routes.IndexController.onPageLoad()
-    case None =>routes.IndexController.onPageLoad()
-  }
-
 }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -33,7 +33,12 @@ class Navigator @Inject()() {
     CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)),
     TrustResidentInUKPage -> TrustResidentinUKRoute(),
     EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)),
-    TrustResidentOffshorePage -> (_ => routes.IndexController.onPageLoad()))
+    TrustResidentOffshorePage -> TrustResidentOffshoreRoute(),
+    RegisteringTrustFor5APage -> RegisteringTrustFor5ARoute(),
+    NonResidentTypePage -> (_ => routes.IndexController.onPageLoad()),
+    InheritanceTaxActPage -> (_ => routes.IndexController.onPageLoad())
+  )
+
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 
@@ -61,6 +66,18 @@ class Navigator @Inject()() {
   private def TrustResidentinUKRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
     case Some(true) => routes.EstablishedUnderScotsLawController.onPageLoad(NormalMode)
     case Some(false) => routes.RegisteringTrustFor5AController.onPageLoad(NormalMode)
+    case None =>routes.IndexController.onPageLoad()
+  }
+
+  private def TrustResidentOffshoreRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
+    case Some(true) => routes.TrustPreviouslyResidentController.onPageLoad(NormalMode)
+    case Some(false) => routes.IndexController.onPageLoad()
+    case None =>routes.IndexController.onPageLoad()
+  }
+
+  private def RegisteringTrustFor5ARoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
+    case Some(true) => routes.NonResidentTypeController.onPageLoad(NormalMode)
+    case Some(false) => routes.InheritanceTaxActController.onPageLoad(NormalMode)
     case None =>routes.IndexController.onPageLoad()
   }
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -32,7 +32,8 @@ class Navigator @Inject()() {
     AdministrationOutsideUKPage -> AdministrationOutsideUKRoute(),
     CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)),
     TrustResidentInUKPage -> TrustResidentinUKRoute(),
-    EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)))
+    EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)),
+    TrustResidentOffshorePage -> (_ => routes.IndexController.onPageLoad()))
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -28,22 +28,54 @@ class Navigator @Inject()() {
   private val routeMap: Map[Page, UserAnswers => Call] = Map(
     TrustNamePage -> (_ => routes.WhenTrustSetupController.onPageLoad(NormalMode)),
     WhenTrustSetupPage -> (_ => routes.GovernedOutsideTheUKController.onPageLoad(NormalMode)),
-    GovernedOutsideTheUKPage -> isTrustGovernedOutsideUK,
+    GovernedOutsideTheUKPage -> isTrustGovernedOutsideUKRoute,
     CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)),
-    AdministrationOutsideUKPage -> isTrustGeneralAdministration,
-    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode))
+    AdministrationOutsideUKPage -> isTrustGeneralAdministrationRoute,
+    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)),
+    TrustResidentInUKPage -> isTrustResidentInUKRoute,
+    EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)),
+    TrustResidentOffshorePage -> wasTrustPreviouslyResidentOffshoreRoute,
+    TrustPreviouslyResidentPage -> (_ => routes.CheckYourAnswersController.onPageLoad()),
+    RegisteringTrustFor5APage -> registeringForPurposeOfSchedule5ARoute,
+    NonResidentTypePage -> (_ => routes.CheckYourAnswersController.onPageLoad()),
+    InheritanceTaxActPage -> inheritanceTaxRoute,
+    AgentOtherThanBarristerPage -> (_ => routes.CheckYourAnswersController.onPageLoad())
   )
 
-  private def isTrustGovernedOutsideUK(answers: UserAnswers) = answers.get(GovernedOutsideTheUKPage) match {
+  private def isTrustGovernedOutsideUKRoute(answers: UserAnswers) = answers.get(GovernedOutsideTheUKPage) match {
     case Some(true)  => routes.CountryGoverningTrustController.onPageLoad(NormalMode)
     case Some(false) => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)
     case None        => routes.SessionExpiredController.onPageLoad()
   }
 
-  private def isTrustGeneralAdministration(answers: UserAnswers) = answers.get(AdministrationOutsideUKPage) match {
+  private def isTrustGeneralAdministrationRoute(answers: UserAnswers) = answers.get(AdministrationOutsideUKPage) match {
     case Some(true)  => routes.CountryAdministeringTrustController.onPageLoad(NormalMode)
     case Some(false) => routes.TrustResidentInUKController.onPageLoad(NormalMode)
     case None        => routes.SessionExpiredController.onPageLoad()
+  }
+
+  private def isTrustResidentInUKRoute(answers: UserAnswers) = answers.get(TrustResidentInUKPage) match {
+    case Some(true)   => routes.EstablishedUnderScotsLawController.onPageLoad(NormalMode)
+    case Some(false)  => routes.RegisteringTrustFor5AController.onPageLoad(NormalMode)
+    case None         => routes.SessionExpiredController.onPageLoad()
+  }
+
+  private def wasTrustPreviouslyResidentOffshoreRoute(answers: UserAnswers) = answers.get(TrustResidentOffshorePage) match {
+    case Some(true)   => routes.TrustPreviouslyResidentController.onPageLoad(NormalMode)
+    case Some(false)  => routes.CheckYourAnswersController.onPageLoad()
+    case None         => routes.SessionExpiredController.onPageLoad()
+  }
+
+  private def registeringForPurposeOfSchedule5ARoute(answers: UserAnswers) = answers.get(RegisteringTrustFor5APage) match {
+    case Some(true)   => routes.NonResidentTypeController.onPageLoad(NormalMode)
+    case Some(false)  => routes.InheritanceTaxActController.onPageLoad(NormalMode)
+    case None         => routes.SessionExpiredController.onPageLoad()
+  }
+
+  private def inheritanceTaxRoute(answers: UserAnswers) = answers.get(InheritanceTaxActPage) match {
+    case Some(true)   => routes.AgentOtherThanBarristerController.onPageLoad(NormalMode)
+    case Some(false)  => routes.CheckYourAnswersController.onPageLoad()
+    case None         => routes.SessionExpiredController.onPageLoad()
   }
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -27,8 +27,9 @@ import models._
 class Navigator @Inject()() {
 
   private val routeMap: Map[Page, UserAnswers => Call] = Map(
-
-  )
+    TrustNamePage -> (_ => routes.GovernedOutsideTheUKController.onPageLoad(NormalMode)),
+    GovernedOutsideTheUKPage -> GovernedOutsideTheUKRoute(),
+    CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)))
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 
@@ -39,5 +40,11 @@ class Navigator @Inject()() {
       routeMap.getOrElse(page, _ => routes.IndexController.onPageLoad())
     case CheckMode =>
       checkRouteMap.getOrElse(page, _ => routes.CheckYourAnswersController.onPageLoad())
+  }
+
+  private def GovernedOutsideTheUKRoute()(answers: UserAnswers ) = answers.get(GovernedOutsideTheUKPage) match {
+    case Some(true) => routes.CountryGoverningTrustController.onPageLoad(NormalMode)
+    case Some(false) => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)
+    case None =>routes.IndexController.onPageLoad()
   }
 }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -31,7 +31,8 @@ class Navigator @Inject()() {
     CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)),
     AdministrationOutsideUKPage -> AdministrationOutsideUKRoute(),
     CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)),
-    TrustResidentInUKPage -> TrustResidentinUKRoute())
+    TrustResidentInUKPage -> TrustResidentinUKRoute(),
+    EstablishedUnderScotsLawPage -> (_ => routes.TrustResidentOffshoreController.onPageLoad(NormalMode)))
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -17,7 +17,6 @@
 package navigation
 
 import javax.inject.{Inject, Singleton}
-
 import play.api.mvc.Call
 import controllers.routes
 import pages._
@@ -31,7 +30,8 @@ class Navigator @Inject()() {
     GovernedOutsideTheUKPage -> GovernedOutsideTheUKRoute(),
     CountryGoverningTrustPage -> (_ => routes.AdministrationOutsideUKController.onPageLoad(NormalMode)),
     AdministrationOutsideUKPage -> AdministrationOutsideUKRoute(),
-    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)))
+    CountryAdministeringTrustPage -> (_ => routes.TrustResidentInUKController.onPageLoad(NormalMode)),
+    TrustResidentInUKPage -> TrustResidentinUKRoute())
 
   private val checkRouteMap: Map[Page, UserAnswers => Call] = Map(
 
@@ -53,6 +53,12 @@ class Navigator @Inject()() {
   private def AdministrationOutsideUKRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
     case Some(true) => routes.CountryAdministeringTrustController.onPageLoad(NormalMode)
     case Some(false) => routes.TrustResidentInUKController.onPageLoad(NormalMode)
+    case None =>routes.IndexController.onPageLoad()
+  }
+
+  private def TrustResidentinUKRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
+    case Some(true) => routes.EstablishedUnderScotsLawController.onPageLoad(NormalMode)
+    case Some(false) => routes.RegisteringTrustFor5AController.onPageLoad(NormalMode)
     case None =>routes.IndexController.onPageLoad()
   }
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -37,7 +37,8 @@ class Navigator @Inject()() {
     TrustPreviouslyResidentPage -> (_ => routes.IndexController.onPageLoad()),
     RegisteringTrustFor5APage -> RegisteringTrustFor5ARoute(),
     NonResidentTypePage -> (_ => routes.IndexController.onPageLoad()),
-    InheritanceTaxActPage -> (_ => routes.IndexController.onPageLoad())
+    InheritanceTaxActPage -> InheritanceTaxActRoute(),
+    AgentOtherThanBarristerPage -> (_ => routes.IndexController.onPageLoad())
   )
 
 
@@ -79,6 +80,12 @@ class Navigator @Inject()() {
   private def RegisteringTrustFor5ARoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
     case Some(true) => routes.NonResidentTypeController.onPageLoad(NormalMode)
     case Some(false) => routes.InheritanceTaxActController.onPageLoad(NormalMode)
+    case None =>routes.IndexController.onPageLoad()
+  }
+
+  private def InheritanceTaxActRoute()(answers: UserAnswers ) = answers.get(AdministrationOutsideUKPage) match {
+    case Some(true) => routes.AgentOtherThanBarristerController.onPageLoad(NormalMode)
+    case Some(false) => routes.IndexController.onPageLoad()
     case None =>routes.IndexController.onPageLoad()
   }
 

--- a/app/pages/AdministrationOutsideUKPage.scala
+++ b/app/pages/AdministrationOutsideUKPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object AdministrationOutsideUKPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "administrationOutsideUK"
+}

--- a/app/pages/AdministrationOutsideUKPage.scala
+++ b/app/pages/AdministrationOutsideUKPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/AgentOtherThanBarristerPage.scala
+++ b/app/pages/AgentOtherThanBarristerPage.scala
@@ -16,17 +16,11 @@
 
 package pages
 
-import models.Non-residentType
-import pages.behaviours.PageBehaviours
+import play.api.libs.json.JsPath
 
-class Non-residentTypeSpec extends PageBehaviours {
+case object AgentOtherThanBarristerPage extends QuestionPage[Boolean] {
 
-  "Non-residentTypePage" must {
+  override def path: JsPath = JsPath \ toString
 
-    beRetrievable[Non-residentType](Non-residentTypePage)
-
-    beSettable[Non-residentType](Non-residentTypePage)
-
-    beRemovable[Non-residentType](Non-residentTypePage)
-  }
+  override def toString: String = "agentOtherThanBarrister"
 }

--- a/app/pages/CountryAdministeringTrustPage.scala
+++ b/app/pages/CountryAdministeringTrustPage.scala
@@ -16,17 +16,11 @@
 
 package pages
 
-import pages.behaviours.PageBehaviours
+import play.api.libs.json.JsPath
 
+case object CountryAdministeringTrustPage extends QuestionPage[String] {
 
-class TrustNamePageSpec extends PageBehaviours {
+  override def path: JsPath = JsPath \ toString
 
-  "TrustNamePage" must {
-
-    beRetrievable[String](TrustNamePage)
-
-    beSettable[String](TrustNamePage)
-
-    beRemovable[String](TrustNamePage)
-  }
+  override def toString: String = "countryAdministeringTrust"
 }

--- a/app/pages/CountryGoverningTrustPage.scala
+++ b/app/pages/CountryGoverningTrustPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/CountryGoverningTrustPage.scala
+++ b/app/pages/CountryGoverningTrustPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object CountryGoverningTrustPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "countryGoverningTrust"
+}

--- a/app/pages/EstablishedUnderScotsLawPage.scala
+++ b/app/pages/EstablishedUnderScotsLawPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object EstablishedUnderScotsLawPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "establishedUnderScotsLaw"
+}

--- a/app/pages/GovernedOutsideTheUKPage.scala
+++ b/app/pages/GovernedOutsideTheUKPage.scala
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package generators
+package pages
 
-import org.scalacheck.Arbitrary
-import pages._
+import play.api.libs.json.JsPath
 
-trait PageGenerators {
+case object GovernedOutsideTheUKPage extends QuestionPage[Boolean] {
 
-  implicit lazy val arbitraryGovernedOutsideTheUKPage: Arbitrary[GovernedOutsideTheUKPage.type] =
-    Arbitrary(GovernedOutsideTheUKPage)
+  override def path: JsPath = JsPath \ toString
 
-  implicit lazy val arbitraryTrustNamePage: Arbitrary[TrustNamePage.type] =
-    Arbitrary(TrustNamePage)
+  override def toString: String = "governedOutsideTheUK"
 }

--- a/app/pages/InheritanceTaxActPage.scala
+++ b/app/pages/InheritanceTaxActPage.scala
@@ -18,9 +18,9 @@ package pages
 
 import play.api.libs.json.JsPath
 
-case object TrustPreviouslyResidentPage extends QuestionPage[String] {
+case object InheritanceTaxActPage extends QuestionPage[Boolean] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "trustPreviouslyResident"
+  override def toString: String = "inheritanceTaxAct"
 }

--- a/app/pages/NonResidentTypePage.scala
+++ b/app/pages/NonResidentTypePage.scala
@@ -16,11 +16,12 @@
 
 package pages
 
+import models.NonResidentType
 import play.api.libs.json.JsPath
 
-case object TrustPreviouslyResidentPage extends QuestionPage[String] {
+case object NonResidentTypePage extends QuestionPage[NonResidentType] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "trustPreviouslyResident"
+  override def toString: String = "nonresidentType"
 }

--- a/app/pages/RegisteringTrustFor5APage.scala
+++ b/app/pages/RegisteringTrustFor5APage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object RegisteringTrustFor5APage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "registeringTrustFor5A"
+}

--- a/app/pages/TrustNamePage.scala
+++ b/app/pages/TrustNamePage.scala
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package utils
+package pages
 
-import controllers.routes
-import models.{CheckMode, UserAnswers}
-import pages._
-import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
+import play.api.libs.json.JsPath
 
-class CheckYourAnswersHelper(userAnswers: UserAnswers) {
+case object TrustNamePage extends QuestionPage[String] {
 
-  def trustName: Option[AnswerRow] = userAnswers.get(TrustNamePage) map {
-    x => AnswerRow("trustName.checkYourAnswersLabel", s"$x", false, routes.TrustNameController.onPageLoad(CheckMode).url)
-  }
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "trustName"
 }

--- a/app/pages/TrustPreviouslyResidentPage.scala
+++ b/app/pages/TrustPreviouslyResidentPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object TrustPreviouslyResidentPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "trustPreviouslyResident"
+}

--- a/app/pages/TrustResidentInUKPage.scala
+++ b/app/pages/TrustResidentInUKPage.scala
@@ -16,17 +16,11 @@
 
 package pages
 
-import pages.behaviours.PageBehaviours
+import play.api.libs.json.JsPath
 
+case object TrustResidentInUKPage extends QuestionPage[Boolean] {
 
-class TrustNamePageSpec extends PageBehaviours {
+  override def path: JsPath = JsPath \ toString
 
-  "TrustNamePage" must {
-
-    beRetrievable[String](TrustNamePage)
-
-    beSettable[String](TrustNamePage)
-
-    beRemovable[String](TrustNamePage)
-  }
+  override def toString: String = "trustResidentInUK"
 }

--- a/app/pages/TrustResidentOffshorePage.scala
+++ b/app/pages/TrustResidentOffshorePage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object TrustResidentOffshorePage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "trustResidentOffshore"
+}

--- a/app/pages/WhenTrustSetupPage.scala
+++ b/app/pages/WhenTrustSetupPage.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import viewmodels.AnswerRow
+package pages
 
-@(row: AnswerRow)(implicit messages: Messages)
+import java.time.LocalDate
 
-<li>
-    <div class="cya-question">@messages(row.label)</div>
-    <div class="cya-answer">
-        @row.answer
-    </div>
-    <div class="cya-change">
-        <a href='@row.changeUrl'>
-            <span aria-hidden="true">@messages("site.edit")</span>
-            <span class="visually-hidden">@messages("site.hidden-edit", messages(row.label))</span>
-        </a>
-    </div>
-</li>
+import play.api.libs.json.JsPath
+
+case object WhenTrustSetupPage extends QuestionPage[LocalDate] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "whenTrustSetup"
+}

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,14 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def registeringTrustFor5A: Option[AnswerRow] = userAnswers.get(RegisteringTrustFor5APage) map {
+    x => AnswerRow("registeringTrustFor5A.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.RegisteringTrustFor5AController.onPageLoad(CheckMode).url)
+  }
+
+  def establishedUnderScotsLaw: Option[AnswerRow] = userAnswers.get(EstablishedUnderScotsLawPage) map {
+    x => AnswerRow("establishedUnderScotsLaw.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.EstablishedUnderScotsLawController.onPageLoad(CheckMode).url)
+  }
+
   def trustResidentInUK: Option[AnswerRow] = userAnswers.get(TrustResidentInUKPage) map {
     x => AnswerRow("trustResidentInUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.TrustResidentInUKController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,12 +23,16 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def agentOtherThanBarrister: Option[AnswerRow] = userAnswers.get(AgentOtherThanBarristerPage) map {
+    x => AnswerRow("agentOtherThanBarrister.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.AgentOtherThanBarristerController.onPageLoad(CheckMode).url)
+  }
+
   def inheritanceTaxAct: Option[AnswerRow] = userAnswers.get(InheritanceTaxActPage) map {
     x => AnswerRow("inheritanceTaxAct.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.InheritanceTaxActController.onPageLoad(CheckMode).url)
   }
 
-  def non-residentType: Option[AnswerRow] = userAnswers.get(Non-residentTypePage) map {
-    x => AnswerRow("non-residentType.checkYourAnswersLabel", s"non-residentType.$x", true, routes.Non-residentTypeController.onPageLoad(CheckMode).url)
+  def nonresidentType: Option[AnswerRow] = userAnswers.get(NonResidentTypePage) map {
+    x => AnswerRow("non-residentType.checkYourAnswersLabel", s"non-residentType.$x", true, routes.NonResidentTypeController.onPageLoad(CheckMode).url)
   }
 
   def trustPreviouslyResident: Option[AnswerRow] = userAnswers.get(TrustPreviouslyResidentPage) map {

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,10 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def administrationOutsideUK: Option[AnswerRow] = userAnswers.get(AdministrationOutsideUKPage) map {
+    x => AnswerRow("administrationOutsideUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.AdministrationOutsideUKController.onPageLoad(CheckMode).url)
+  }
+
   def countryGoverningTrust: Option[AnswerRow] = userAnswers.get(CountryGoverningTrustPage) map {
     x => AnswerRow("countryGoverningTrust.checkYourAnswersLabel", s"$x", false, routes.CountryGoverningTrustController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -16,62 +16,93 @@
 
 package utils
 
-import controllers.routes
-import models.{CheckMode, UserAnswers}
-import pages._
-import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
+import java.time.format.DateTimeFormatter
 
-class CheckYourAnswersHelper(userAnswers: UserAnswers) {
+import controllers.routes
+import models.{CheckMode, NonResidentType, UserAnswers}
+import pages._
+import play.api.i18n.Messages
+import play.twirl.api.{Html, HtmlFormat}
+import utils.CheckYourAnswersHelper._
+import viewmodels.AnswerRow
+
+class CheckYourAnswersHelper(userAnswers: UserAnswers)(implicit messages: Messages) {
+
+  def whenTrustSetup: Option[AnswerRow] = userAnswers.get(WhenTrustSetupPage) map {
+    x =>
+      AnswerRow(
+        "whenTrustSetup.checkYourAnswersLabel",
+        HtmlFormat.escape(x.format(dateFormatter)),
+        routes.WhenTrustSetupController.onPageLoad(CheckMode).url
+      )
+  }
 
   def agentOtherThanBarrister: Option[AnswerRow] = userAnswers.get(AgentOtherThanBarristerPage) map {
-    x => AnswerRow("agentOtherThanBarrister.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.AgentOtherThanBarristerController.onPageLoad(CheckMode).url)
+    x => AnswerRow("agentOtherThanBarrister.checkYourAnswersLabel", yesOrNo(x), routes.AgentOtherThanBarristerController.onPageLoad(CheckMode).url)
   }
 
   def inheritanceTaxAct: Option[AnswerRow] = userAnswers.get(InheritanceTaxActPage) map {
-    x => AnswerRow("inheritanceTaxAct.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.InheritanceTaxActController.onPageLoad(CheckMode).url)
+    x => AnswerRow("inheritanceTaxAct.checkYourAnswersLabel", yesOrNo(x), routes.InheritanceTaxActController.onPageLoad(CheckMode).url)
   }
 
   def nonresidentType: Option[AnswerRow] = userAnswers.get(NonResidentTypePage) map {
-    x => AnswerRow("non-residentType.checkYourAnswersLabel", s"non-residentType.$x", true, routes.NonResidentTypeController.onPageLoad(CheckMode).url)
+    x => AnswerRow("nonresidentType.checkYourAnswersLabel", answer("nonresidentType", x), routes.NonResidentTypeController.onPageLoad(CheckMode).url)
   }
 
   def trustPreviouslyResident: Option[AnswerRow] = userAnswers.get(TrustPreviouslyResidentPage) map {
-    x => AnswerRow("trustPreviouslyResident.checkYourAnswersLabel", s"$x", false, routes.TrustPreviouslyResidentController.onPageLoad(CheckMode).url)
+    x => AnswerRow("trustPreviouslyResident.checkYourAnswersLabel", escape(x), routes.TrustPreviouslyResidentController.onPageLoad(CheckMode).url)
   }
 
   def trustResidentOffshore: Option[AnswerRow] = userAnswers.get(TrustResidentOffshorePage) map {
-    x => AnswerRow("trustResidentOffshore.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.TrustResidentOffshoreController.onPageLoad(CheckMode).url)
+    x => AnswerRow("trustResidentOffshore.checkYourAnswersLabel", yesOrNo(x), routes.TrustResidentOffshoreController.onPageLoad(CheckMode).url)
   }
 
   def registeringTrustFor5A: Option[AnswerRow] = userAnswers.get(RegisteringTrustFor5APage) map {
-    x => AnswerRow("registeringTrustFor5A.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.RegisteringTrustFor5AController.onPageLoad(CheckMode).url)
+    x => AnswerRow("registeringTrustFor5A.checkYourAnswersLabel", yesOrNo(x), routes.RegisteringTrustFor5AController.onPageLoad(CheckMode).url)
   }
 
   def establishedUnderScotsLaw: Option[AnswerRow] = userAnswers.get(EstablishedUnderScotsLawPage) map {
-    x => AnswerRow("establishedUnderScotsLaw.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.EstablishedUnderScotsLawController.onPageLoad(CheckMode).url)
+    x => AnswerRow("establishedUnderScotsLaw.checkYourAnswersLabel", yesOrNo(x), routes.EstablishedUnderScotsLawController.onPageLoad(CheckMode).url)
   }
 
   def trustResidentInUK: Option[AnswerRow] = userAnswers.get(TrustResidentInUKPage) map {
-    x => AnswerRow("trustResidentInUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.TrustResidentInUKController.onPageLoad(CheckMode).url)
+    x => AnswerRow("trustResidentInUK.checkYourAnswersLabel", yesOrNo(x), routes.TrustResidentInUKController.onPageLoad(CheckMode).url)
   }
 
   def countryAdministeringTrust: Option[AnswerRow] = userAnswers.get(CountryAdministeringTrustPage) map {
-    x => AnswerRow("countryAdministeringTrust.checkYourAnswersLabel", s"$x", false, routes.CountryAdministeringTrustController.onPageLoad(CheckMode).url)
+    x => AnswerRow("countryAdministeringTrust.checkYourAnswersLabel", escape(x), routes.CountryAdministeringTrustController.onPageLoad(CheckMode).url)
   }
 
   def administrationOutsideUK: Option[AnswerRow] = userAnswers.get(AdministrationOutsideUKPage) map {
-    x => AnswerRow("administrationOutsideUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.AdministrationOutsideUKController.onPageLoad(CheckMode).url)
+    x => AnswerRow("administrationOutsideUK.checkYourAnswersLabel", yesOrNo(x), routes.AdministrationOutsideUKController.onPageLoad(CheckMode).url)
   }
 
   def countryGoverningTrust: Option[AnswerRow] = userAnswers.get(CountryGoverningTrustPage) map {
-    x => AnswerRow("countryGoverningTrust.checkYourAnswersLabel", s"$x", false, routes.CountryGoverningTrustController.onPageLoad(CheckMode).url)
+    x => AnswerRow("countryGoverningTrust.checkYourAnswersLabel", escape(x), routes.CountryGoverningTrustController.onPageLoad(CheckMode).url)
   }
 
   def governedOutsideTheUK: Option[AnswerRow] = userAnswers.get(GovernedOutsideTheUKPage) map {
-    x => AnswerRow("governedOutsideTheUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.GovernedOutsideTheUKController.onPageLoad(CheckMode).url)
+    x => AnswerRow("governedOutsideTheUK.checkYourAnswersLabel", yesOrNo(x), routes.GovernedOutsideTheUKController.onPageLoad(CheckMode).url)
   }
 
   def trustName: Option[AnswerRow] = userAnswers.get(TrustNamePage) map {
-    x => AnswerRow("trustName.checkYourAnswersLabel", s"$x", false, routes.TrustNameController.onPageLoad(CheckMode).url)
+    x => AnswerRow("trustName.checkYourAnswersLabel", escape(x), routes.TrustNameController.onPageLoad(CheckMode).url)
   }
+}
+
+object CheckYourAnswersHelper {
+  private val dateFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy")
+
+  private def yesOrNo(answer: Boolean)(implicit messages: Messages): Html =
+    if (answer) {
+      HtmlFormat.escape(messages("site.yes"))
+    } else {
+      HtmlFormat.escape(messages("site.no"))
+    }
+
+
+  private def answer[T](key : String, answer: T)(implicit messages: Messages) : Html =
+    HtmlFormat.escape(messages(s"$key.$answer"))
+
+  private def escape(x : String) = HtmlFormat.escape(x)
 }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,10 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def governedOutsideTheUK: Option[AnswerRow] = userAnswers.get(GovernedOutsideTheUKPage) map {
+    x => AnswerRow("governedOutsideTheUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.GovernedOutsideTheUKController.onPageLoad(CheckMode).url)
+  }
+
   def trustName: Option[AnswerRow] = userAnswers.get(TrustNamePage) map {
     x => AnswerRow("trustName.checkYourAnswersLabel", s"$x", false, routes.TrustNameController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,14 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def inheritanceTaxAct: Option[AnswerRow] = userAnswers.get(InheritanceTaxActPage) map {
+    x => AnswerRow("inheritanceTaxAct.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.InheritanceTaxActController.onPageLoad(CheckMode).url)
+  }
+
+  def non-residentType: Option[AnswerRow] = userAnswers.get(Non-residentTypePage) map {
+    x => AnswerRow("non-residentType.checkYourAnswersLabel", s"non-residentType.$x", true, routes.Non-residentTypeController.onPageLoad(CheckMode).url)
+  }
+
   def trustPreviouslyResident: Option[AnswerRow] = userAnswers.get(TrustPreviouslyResidentPage) map {
     x => AnswerRow("trustPreviouslyResident.checkYourAnswersLabel", s"$x", false, routes.TrustPreviouslyResidentController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,10 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def countryGoverningTrust: Option[AnswerRow] = userAnswers.get(CountryGoverningTrustPage) map {
+    x => AnswerRow("countryGoverningTrust.checkYourAnswersLabel", s"$x", false, routes.CountryGoverningTrustController.onPageLoad(CheckMode).url)
+  }
+
   def governedOutsideTheUK: Option[AnswerRow] = userAnswers.get(GovernedOutsideTheUKPage) map {
     x => AnswerRow("governedOutsideTheUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.GovernedOutsideTheUKController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,10 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def trustResidentOffshore: Option[AnswerRow] = userAnswers.get(TrustResidentOffshorePage) map {
+    x => AnswerRow("trustResidentOffshore.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.TrustResidentOffshoreController.onPageLoad(CheckMode).url)
+  }
+
   def registeringTrustFor5A: Option[AnswerRow] = userAnswers.get(RegisteringTrustFor5APage) map {
     x => AnswerRow("registeringTrustFor5A.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.RegisteringTrustFor5AController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,10 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def trustPreviouslyResident: Option[AnswerRow] = userAnswers.get(TrustPreviouslyResidentPage) map {
+    x => AnswerRow("trustPreviouslyResident.checkYourAnswersLabel", s"$x", false, routes.TrustPreviouslyResidentController.onPageLoad(CheckMode).url)
+  }
+
   def trustResidentOffshore: Option[AnswerRow] = userAnswers.get(TrustResidentOffshorePage) map {
     x => AnswerRow("trustResidentOffshore.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.TrustResidentOffshoreController.onPageLoad(CheckMode).url)
   }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -23,6 +23,14 @@ import viewmodels.{AnswerRow, RepeaterAnswerRow, RepeaterAnswerSection}
 
 class CheckYourAnswersHelper(userAnswers: UserAnswers) {
 
+  def trustResidentInUK: Option[AnswerRow] = userAnswers.get(TrustResidentInUKPage) map {
+    x => AnswerRow("trustResidentInUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.TrustResidentInUKController.onPageLoad(CheckMode).url)
+  }
+
+  def countryAdministeringTrust: Option[AnswerRow] = userAnswers.get(CountryAdministeringTrustPage) map {
+    x => AnswerRow("countryAdministeringTrust.checkYourAnswersLabel", s"$x", false, routes.CountryAdministeringTrustController.onPageLoad(CheckMode).url)
+  }
+
   def administrationOutsideUK: Option[AnswerRow] = userAnswers.get(AdministrationOutsideUKPage) map {
     x => AnswerRow("administrationOutsideUK.checkYourAnswersLabel", if(x) "site.yes" else "site.no", true, routes.AdministrationOutsideUKController.onPageLoad(CheckMode).url)
   }

--- a/app/viewmodels/AnswerRow.scala
+++ b/app/viewmodels/AnswerRow.scala
@@ -16,4 +16,6 @@
 
 package viewmodels
 
-case class AnswerRow(label: String, answer: String, answerIsMessageKey: Boolean, changeUrl: String)
+import play.twirl.api.Html
+
+case class AnswerRow(label: String, answer: Html, changeUrl: String)

--- a/app/views/AdministrationOutsideUKView.scala.html
+++ b/app/views/AdministrationOutsideUKView.scala.html
@@ -1,0 +1,31 @@
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("administrationOutsideUK.title")}"
+    ) {
+
+    @formHelper(action = AdministrationOutsideUKController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("administrationOutsideUK.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("administrationOutsideUK.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/AdministrationOutsideUKView.scala.html
+++ b/app/views/AdministrationOutsideUKView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import controllers.routes._
 @import models.Mode
 

--- a/app/views/AgentOtherThanBarristerView.scala.html
+++ b/app/views/AgentOtherThanBarristerView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("agentOtherThanBarrister.title")}"
+    ) {
+
+    @formHelper(action = AgentOtherThanBarristerController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("agentOtherThanBarrister.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("agentOtherThanBarrister.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/CountryAdministeringTrustView.scala.html
+++ b/app/views/CountryAdministeringTrustView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("countryAdministeringTrust.title")}"
+    ) {
+
+    @formHelper(action = CountryAdministeringTrustController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("countryAdministeringTrust.heading")
+
+        @components.input_text(
+          field = form("value"),
+          label = messages("countryAdministeringTrust.heading"),
+          labelClass=Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/CountryGoverningTrustView.scala.html
+++ b/app/views/CountryGoverningTrustView.scala.html
@@ -1,0 +1,31 @@
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("countryGoverningTrust.title")}"
+    ) {
+
+    @formHelper(action = CountryGoverningTrustController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("countryGoverningTrust.heading")
+
+        @components.input_text(
+          field = form("value"),
+          label = messages("countryGoverningTrust.heading"),
+          labelClass=Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/CountryGoverningTrustView.scala.html
+++ b/app/views/CountryGoverningTrustView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import controllers.routes._
 @import models.Mode
 

--- a/app/views/EstablishedUnderScotsLawView.scala.html
+++ b/app/views/EstablishedUnderScotsLawView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("establishedUnderScotsLaw.title")}"
+    ) {
+
+    @formHelper(action = EstablishedUnderScotsLawController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("establishedUnderScotsLaw.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("establishedUnderScotsLaw.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/GovernedOutsideTheUKView.scala.html
+++ b/app/views/GovernedOutsideTheUKView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("governedOutsideTheUK.title")}"
+    ) {
+
+    @formHelper(action = GovernedOutsideTheUKController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("governedOutsideTheUK.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("governedOutsideTheUK.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/InheritanceTaxActView.scala.html
+++ b/app/views/InheritanceTaxActView.scala.html
@@ -25,21 +25,21 @@
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = s"${errorPrefix(form)} ${messages("trustPreviouslyResident.title")}"
+    title = s"${errorPrefix(form)} ${messages("inheritanceTaxAct.title")}"
     ) {
 
-    @formHelper(action = TrustPreviouslyResidentController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = InheritanceTaxActController.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.back_link()
 
         @components.error_summary(form.errors)
 
-        @components.heading("trustPreviouslyResident.heading")
+        @components.heading("inheritanceTaxAct.heading")
 
-        @components.input_text(
-          field = form("value"),
-          label = messages("trustPreviouslyResident.heading"),
-          labelClass=Some("visually-hidden")
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("inheritanceTaxAct.heading"),
+            labelClass = Some("visually-hidden")
         )
 
         @components.submit_button()

--- a/app/views/NonResidentTypeView.scala.html
+++ b/app/views/NonResidentTypeView.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import controllers.routes._
-@import models.Mode
+@import models.{Mode, NonResidentType}
 
 @this(
     main_template: MainTemplate,
@@ -25,21 +25,22 @@
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = s"${errorPrefix(form)} ${messages("trustPreviouslyResident.title")}"
+    title = s"${errorPrefix(form)} ${messages("nonresidentType.title")}"
     ) {
 
-    @formHelper(action = TrustPreviouslyResidentController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = NonResidentTypeController.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.back_link()
 
         @components.error_summary(form.errors)
 
-        @components.heading("trustPreviouslyResident.heading")
+        @components.heading("nonresidentType.heading")
 
-        @components.input_text(
-          field = form("value"),
-          label = messages("trustPreviouslyResident.heading"),
-          labelClass=Some("visually-hidden")
+        @components.input_radio(
+            field = form("value"),
+            legend = messages("nonresidentType.heading"),
+            legendClass = Some("visually-hidden"),
+            inputs = NonResidentType.options.toSeq
         )
 
         @components.submit_button()

--- a/app/views/RegisteringTrustFor5AView.scala.html
+++ b/app/views/RegisteringTrustFor5AView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("registeringTrustFor5A.title")}"
+    ) {
+
+    @formHelper(action = RegisteringTrustFor5AController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("registeringTrustFor5A.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("registeringTrustFor5A.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/TrustNameView.scala.html
+++ b/app/views/TrustNameView.scala.html
@@ -1,0 +1,48 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers._
+@import models.Mode
+
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("trustName.title")}"
+    ) {
+
+    @formHelper(action = TrustNameController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("trustName.heading")
+
+        @components.input_text(
+          field = form("value"),
+          label = messages("trustName.heading"),
+          labelClass=Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/TrustPreviouslyResidentView.scala.html
+++ b/app/views/TrustPreviouslyResidentView.scala.html
@@ -1,0 +1,31 @@
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("trustPreviouslyResident.title")}"
+    ) {
+
+    @formHelper(action = TrustPreviouslyResidentController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("trustPreviouslyResident.heading")
+
+        @components.input_text(
+          field = form("value"),
+          label = messages("trustPreviouslyResident.heading"),
+          labelClass=Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/TrustResidentInUKView.scala.html
+++ b/app/views/TrustResidentInUKView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("trustResidentInUK.title")}"
+    ) {
+
+    @formHelper(action = TrustResidentInUKController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("trustResidentInUK.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("trustResidentInUK.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/TrustResidentOffshoreView.scala.html
+++ b/app/views/TrustResidentOffshoreView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.routes._
+@import models.Mode
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("trustResidentOffshore.title")}"
+    ) {
+
+    @formHelper(action = TrustResidentOffshoreController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("trustResidentOffshore.heading")
+
+        @components.input_yes_no(
+            field = form("value"),
+            label = messages("trustResidentOffshore.heading"),
+            labelClass = Some("visually-hidden")
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/WhenTrustSetupView.scala.html
+++ b/app/views/WhenTrustSetupView.scala.html
@@ -1,0 +1,44 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+        main_template: MainTemplate,
+        formHelper: FormWithCSRF
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = s"${errorPrefix(form)} ${messages("whenTrustSetup.title")}"
+) {
+
+    @formHelper(action = WhenTrustSetupController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("whenTrustSetup.heading")
+
+        @components.input_date(
+            field = form("value"),
+            legend = messages("whenTrustSetup.heading"),
+            legendClass = "visually-hidden"
+        )
+
+        @components.submit_button()
+    }
+}

--- a/app/views/components/input_date.scala.html
+++ b/app/views/components/input_date.scala.html
@@ -15,55 +15,29 @@
  *@
 
 @(
-id: String,
-label: String,
-legendClass: String = "",
-errorKey: String,
-dayErrorKey: String,
-monthErrorKey: String,
-yearErrorKey: String,
-valueDay: Option[String] = None,
-valueMonth: Option[String] = None,
-valueYear: Option[String] = None,
-secondaryLabel: Option[String] = None,
-hint: Option[String] = None
+  field: Field,
+  legend: String,
+  legendClass: String = "",
+  hint: Option[String] = None
 )(implicit messages: Messages)
 
-<div class="form-group @if(errorKey.nonEmpty || dayErrorKey.nonEmpty || monthErrorKey.nonEmpty || yearErrorKey.nonEmpty){form-group-error}">
+<div class="form-group @if(field("day").hasErrors || field("month").hasErrors || field("year").hasErrors || field.hasErrors){form-group-error}">
     <fieldset>
         <legend>
-        <span class="form-label bold @if(legendClass.nonEmpty){@legendClass}">
-          @label
-        </span>
-        @if(hint.nonEmpty){
-            <span class="form-hint" id="@{id}-date-hint">@hint</span>
-        }
-            @if(errorKey.nonEmpty){
-                <span class="error-message" id="error-message-@{id}-date">@messages(errorKey)</span>
-            }
-            @if(dayErrorKey.nonEmpty){
-                <span class="error-message" id="error-message-@{id}-day">@messages(dayErrorKey)</span>
-            }
-            @if(monthErrorKey.nonEmpty){
-                <span class="error-message" id="error-message-@{id}-month">@messages(monthErrorKey)</span>
-            }
-            @if(yearErrorKey.nonEmpty){
-                <span class="error-message" id="error-message-@{id}-year">@messages(yearErrorKey)</span>
-            }
+          <span class="form-label bold @legendClass">
+            @legend
+          </span>
+          @if(hint.nonEmpty){
+              <span class="form-hint" id="@field.id-hint">@hint</span>
+          }
         </legend>
         <div class="form-date">
-            <div class="form-group form-group-day">
-                <label class="form-label bold" for="@{id}.day">@messages("date.day")</label>
-                <input class="form-control" id="@{id}.day" name="@{id}.day" type="number" min="1" max="31" aria-describedby="@if(dayErrorKey.nonEmpty){error-message-@{id}-day} else {@{id}-date-hint}" value="@valueDay" />
-            </div>
-            <div class="form-group form-group-month">
-                <label class="form-label bold" for="@{id}.month">@messages("date.month")</label>
-                <input class="form-control" id="@{id}.month" name="@{id}.month" type="number" min="1" max="12" @if(monthErrorKey.nonEmpty){aria-describedby="error-message-@{id}-month" } value="@valueMonth" />
-            </div>
-            <div class="form-group form-group-year">
-                <label class="form-label bold" for="@{id}.year">@messages("date.year")</label>
-                <input class="form-control" id="@{id}.year" name="@{id}.year" type="number" min="1900" max="2050" @if(yearErrorKey.nonEmpty){aria-describedby="error-message-@{id}-year" } value="@valueYear" />
-            </div>
+            @List("day", "month", "year").map { part =>
+              <div class="form-control-wrapper form-group form-group-@part">
+                <label class="form-label" for="@field(part).id">@messages(s"date.$part")</label>
+                <input class="form-control @if(field(part).hasErrors || field.error.exists(_.args.contains(part))){field-error}" id="@field(part).id" name="@field(part).name" type="tel" value="@field(part).value" />
+              </div>
+            }
         </div>
     </fieldset>
 </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -56,3 +56,8 @@ GET        /trustResidentOffshore                        controllers.TrustReside
 POST       /trustResidentOffshore                        controllers.TrustResidentOffshoreController.onSubmit(mode: Mode = NormalMode)
 GET        /changeTrustResidentOffshore                  controllers.TrustResidentOffshoreController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeTrustResidentOffshore                  controllers.TrustResidentOffshoreController.onSubmit(mode: Mode = CheckMode)
+
+GET        /trustPreviouslyResident                        controllers.TrustPreviouslyResidentController.onPageLoad(mode: Mode = NormalMode)
+POST       /trustPreviouslyResident                        controllers.TrustPreviouslyResidentController.onSubmit(mode: Mode = NormalMode)
+GET        /changeTrustPreviouslyResident                  controllers.TrustPreviouslyResidentController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeTrustPreviouslyResident                  controllers.TrustPreviouslyResidentController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,3 +11,8 @@ GET        /this-service-has-been-reset                 controllers.SessionExpir
 GET        /check-your-answers                          controllers.CheckYourAnswersController.onPageLoad
 
 GET        /unauthorised                                controllers.UnauthorisedController.onPageLoad
+
+GET        /trustName                        controllers.TrustNameController.onPageLoad(mode: Mode = NormalMode)
+POST       /trustName                        controllers.TrustNameController.onSubmit(mode: Mode = NormalMode)
+GET        /changeTrustName                  controllers.TrustNameController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeTrustName                  controllers.TrustNameController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -41,3 +41,13 @@ GET        /trustResidentInUK                        controllers.TrustResidentIn
 POST       /trustResidentInUK                        controllers.TrustResidentInUKController.onSubmit(mode: Mode = NormalMode)
 GET        /changeTrustResidentInUK                  controllers.TrustResidentInUKController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeTrustResidentInUK                  controllers.TrustResidentInUKController.onSubmit(mode: Mode = CheckMode)
+
+GET        /establishedUnderScotsLaw                        controllers.EstablishedUnderScotsLawController.onPageLoad(mode: Mode = NormalMode)
+POST       /establishedUnderScotsLaw                        controllers.EstablishedUnderScotsLawController.onSubmit(mode: Mode = NormalMode)
+GET        /changeEstablishedUnderScotsLaw                  controllers.EstablishedUnderScotsLawController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeEstablishedUnderScotsLaw                  controllers.EstablishedUnderScotsLawController.onSubmit(mode: Mode = CheckMode)
+
+GET        /registeringTrustFor5A                        controllers.RegisteringTrustFor5AController.onPageLoad(mode: Mode = NormalMode)
+POST       /registeringTrustFor5A                        controllers.RegisteringTrustFor5AController.onSubmit(mode: Mode = NormalMode)
+GET        /changeRegisteringTrustFor5A                  controllers.RegisteringTrustFor5AController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeRegisteringTrustFor5A                  controllers.RegisteringTrustFor5AController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -16,3 +16,8 @@ GET        /trustName                        controllers.TrustNameController.onP
 POST       /trustName                        controllers.TrustNameController.onSubmit(mode: Mode = NormalMode)
 GET        /changeTrustName                  controllers.TrustNameController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeTrustName                  controllers.TrustNameController.onSubmit(mode: Mode = CheckMode)
+
+GET        /governedOutsideTheUK                        controllers.GovernedOutsideTheUKController.onPageLoad(mode: Mode = NormalMode)
+POST       /governedOutsideTheUK                        controllers.GovernedOutsideTheUKController.onSubmit(mode: Mode = NormalMode)
+GET        /changeGovernedOutsideTheUK                  controllers.GovernedOutsideTheUKController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeGovernedOutsideTheUK                  controllers.GovernedOutsideTheUKController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -71,3 +71,8 @@ GET        /inheritanceTaxAct                        controllers.InheritanceTaxA
 POST       /inheritanceTaxAct                        controllers.InheritanceTaxActController.onSubmit(mode: Mode = NormalMode)
 GET        /changeInheritanceTaxAct                  controllers.InheritanceTaxActController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeInheritanceTaxAct                  controllers.InheritanceTaxActController.onSubmit(mode: Mode = CheckMode)
+
+GET        /agentOtherThanBarrister                        controllers.AgentOtherThanBarristerController.onPageLoad(mode: Mode = NormalMode)
+POST       /agentOtherThanBarrister                        controllers.AgentOtherThanBarristerController.onSubmit(mode: Mode = NormalMode)
+GET        /changeAgentOtherThanBarrister                  controllers.AgentOtherThanBarristerController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeAgentOtherThanBarrister                  controllers.AgentOtherThanBarristerController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -76,3 +76,8 @@ GET        /agentOtherThanBarrister                        controllers.AgentOthe
 POST       /agentOtherThanBarrister                        controllers.AgentOtherThanBarristerController.onSubmit(mode: Mode = NormalMode)
 GET        /changeAgentOtherThanBarrister                  controllers.AgentOtherThanBarristerController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeAgentOtherThanBarrister                  controllers.AgentOtherThanBarristerController.onSubmit(mode: Mode = CheckMode)
+
+GET        /whenTrustSetup                  controllers.WhenTrustSetupController.onPageLoad(mode: Mode = NormalMode)
+POST       /whenTrustSetup                  controllers.WhenTrustSetupController.onSubmit(mode: Mode = NormalMode)
+GET        /changeWhenTrustSetup                        controllers.WhenTrustSetupController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeWhenTrustSetup                        controllers.WhenTrustSetupController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -21,3 +21,8 @@ GET        /governedOutsideTheUK                        controllers.GovernedOuts
 POST       /governedOutsideTheUK                        controllers.GovernedOutsideTheUKController.onSubmit(mode: Mode = NormalMode)
 GET        /changeGovernedOutsideTheUK                  controllers.GovernedOutsideTheUKController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeGovernedOutsideTheUK                  controllers.GovernedOutsideTheUKController.onSubmit(mode: Mode = CheckMode)
+
+GET        /countryGoverningTrust                        controllers.CountryGoverningTrustController.onPageLoad(mode: Mode = NormalMode)
+POST       /countryGoverningTrust                        controllers.CountryGoverningTrustController.onSubmit(mode: Mode = NormalMode)
+GET        /changeCountryGoverningTrust                  controllers.CountryGoverningTrustController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeCountryGoverningTrust                  controllers.CountryGoverningTrustController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -31,3 +31,13 @@ GET        /administrationOutsideUK                        controllers.Administr
 POST       /administrationOutsideUK                        controllers.AdministrationOutsideUKController.onSubmit(mode: Mode = NormalMode)
 GET        /changeAdministrationOutsideUK                  controllers.AdministrationOutsideUKController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeAdministrationOutsideUK                  controllers.AdministrationOutsideUKController.onSubmit(mode: Mode = CheckMode)
+
+GET        /countryAdministeringTrust                        controllers.CountryAdministeringTrustController.onPageLoad(mode: Mode = NormalMode)
+POST       /countryAdministeringTrust                        controllers.CountryAdministeringTrustController.onSubmit(mode: Mode = NormalMode)
+GET        /changeCountryAdministeringTrust                  controllers.CountryAdministeringTrustController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeCountryAdministeringTrust                  controllers.CountryAdministeringTrustController.onSubmit(mode: Mode = CheckMode)
+
+GET        /trustResidentInUK                        controllers.TrustResidentInUKController.onPageLoad(mode: Mode = NormalMode)
+POST       /trustResidentInUK                        controllers.TrustResidentInUKController.onSubmit(mode: Mode = NormalMode)
+GET        /changeTrustResidentInUK                  controllers.TrustResidentInUKController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeTrustResidentInUK                  controllers.TrustResidentInUKController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -26,3 +26,8 @@ GET        /countryGoverningTrust                        controllers.CountryGove
 POST       /countryGoverningTrust                        controllers.CountryGoverningTrustController.onSubmit(mode: Mode = NormalMode)
 GET        /changeCountryGoverningTrust                  controllers.CountryGoverningTrustController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeCountryGoverningTrust                  controllers.CountryGoverningTrustController.onSubmit(mode: Mode = CheckMode)
+
+GET        /administrationOutsideUK                        controllers.AdministrationOutsideUKController.onPageLoad(mode: Mode = NormalMode)
+POST       /administrationOutsideUK                        controllers.AdministrationOutsideUKController.onSubmit(mode: Mode = NormalMode)
+GET        /changeAdministrationOutsideUK                  controllers.AdministrationOutsideUKController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeAdministrationOutsideUK                  controllers.AdministrationOutsideUKController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -61,3 +61,13 @@ GET        /trustPreviouslyResident                        controllers.TrustPrev
 POST       /trustPreviouslyResident                        controllers.TrustPreviouslyResidentController.onSubmit(mode: Mode = NormalMode)
 GET        /changeTrustPreviouslyResident                  controllers.TrustPreviouslyResidentController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeTrustPreviouslyResident                  controllers.TrustPreviouslyResidentController.onSubmit(mode: Mode = CheckMode)
+
+GET        /nonResidentType                        controllers.NonResidentTypeController.onPageLoad(mode: Mode = NormalMode)
+POST       /nonResidentType                        controllers.NonResidentTypeController.onSubmit(mode: Mode = NormalMode)
+GET        /changeNonResidentType                  controllers.NonResidentTypeController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeNonResidentType                  controllers.NonResidentTypeController.onSubmit(mode: Mode = CheckMode)
+
+GET        /inheritanceTaxAct                        controllers.InheritanceTaxActController.onPageLoad(mode: Mode = NormalMode)
+POST       /inheritanceTaxAct                        controllers.InheritanceTaxActController.onSubmit(mode: Mode = NormalMode)
+GET        /changeInheritanceTaxAct                  controllers.InheritanceTaxActController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeInheritanceTaxAct                  controllers.InheritanceTaxActController.onSubmit(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -51,3 +51,8 @@ GET        /registeringTrustFor5A                        controllers.Registering
 POST       /registeringTrustFor5A                        controllers.RegisteringTrustFor5AController.onSubmit(mode: Mode = NormalMode)
 GET        /changeRegisteringTrustFor5A                  controllers.RegisteringTrustFor5AController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeRegisteringTrustFor5A                  controllers.RegisteringTrustFor5AController.onSubmit(mode: Mode = CheckMode)
+
+GET        /trustResidentOffshore                        controllers.TrustResidentOffshoreController.onPageLoad(mode: Mode = NormalMode)
+POST       /trustResidentOffshore                        controllers.TrustResidentOffshoreController.onSubmit(mode: Mode = NormalMode)
+GET        /changeTrustResidentOffshore                  controllers.TrustResidentOffshoreController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeTrustResidentOffshore                  controllers.TrustResidentOffshoreController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -64,3 +64,14 @@ administrationOutsideUK.title = Is the trust's general administration done outsi
 administrationOutsideUK.heading = Is the trust's general administration done outside the UK?
 administrationOutsideUK.checkYourAnswersLabel = administrationOutsideUK
 administrationOutsideUK.error.required = Select yes if administrationOutsideUK
+
+countryAdministeringTrust.title = What is the country administering the trust
+countryAdministeringTrust.heading = What is the country administering the trust?
+countryAdministeringTrust.checkYourAnswersLabel = countryAdministeringTrust
+countryAdministeringTrust.error.required = Enter countryAdministeringTrust
+countryAdministeringTrust.error.length = CountryAdministeringTrust must be 100 characters or less
+
+trustResidentInUK.title = Is the trust resident in the UK
+trustResidentInUK.heading = Is the trust resident in the UK?
+trustResidentInUK.checkYourAnswersLabel = trustResidentInUK
+trustResidentInUK.error.required = Select yes if trustResidentInUK

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -96,3 +96,16 @@ trustPreviouslyResident.heading = Where was the trust previously resident?
 trustPreviouslyResident.checkYourAnswersLabel = trustPreviouslyResident
 trustPreviouslyResident.error.required = Enter trustPreviouslyResident
 trustPreviouslyResident.error.length = TrustPreviouslyResident must be 100 characters or less
+
+nonresidentType.title = What is the non-resident type
+nonresidentType.heading = What is the non-resident type
+nonresidentType.1 = Settlor domiciled trustees are non-resident
+nonresidentType.2 = Settlor non-domiciled becomes domiciled then resident
+nonresidentType.3 = Trustees cease to be resident
+nonresidentType.checkYourAnswersLabel = What is the non-resident type
+nonresidentType.error.required = Select non-residentType
+
+inheritanceTaxAct.title = Are you registering the trust for purpose of Section 218 Inheritance Tax Act 1984
+inheritanceTaxAct.heading = Are you registering the trust for purpose of Section 218 Inheritance Tax Act 1984?
+inheritanceTaxAct.checkYourAnswersLabel = inheritanceTaxAct
+inheritanceTaxAct.error.required = Select yes if inheritanceTaxAct

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -85,3 +85,8 @@ registeringTrustFor5A.title = Are you registering trust for the purpose of Sched
 registeringTrustFor5A.heading = Are you registering trust for the purpose of Schedule 5A Taxation of Chargeable Gains Act 1992?
 registeringTrustFor5A.checkYourAnswersLabel = registeringTrustFor5A
 registeringTrustFor5A.error.required = Select yes if registeringTrustFor5A
+
+trustResidentOffshore.title = Was the trust previously resident offshore
+trustResidentOffshore.heading = Was the trust previously resident offshore?
+trustResidentOffshore.checkYourAnswersLabel = trustResidentOffshore
+trustResidentOffshore.error.required = Select yes if trustResidentOffshore

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -90,3 +90,9 @@ trustResidentOffshore.title = Was the trust previously resident offshore
 trustResidentOffshore.heading = Was the trust previously resident offshore?
 trustResidentOffshore.checkYourAnswersLabel = trustResidentOffshore
 trustResidentOffshore.error.required = Select yes if trustResidentOffshore
+
+trustPreviouslyResident.title = Where was the trust previously resident
+trustPreviouslyResident.heading = Where was the trust previously resident?
+trustPreviouslyResident.checkYourAnswersLabel = trustPreviouslyResident
+trustPreviouslyResident.error.required = Enter trustPreviouslyResident
+trustPreviouslyResident.error.length = TrustPreviouslyResident must be 100 characters or less

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -8,12 +8,12 @@ date.year = Year
 
 error.browser.title.prefix = Error:
 error.boolean = Please give an answer
-error.invalid_date = Give a correct date
 error.date.day_blank = Enter a day
 error.date.day_invalid = Give a correct day using numbers 1 to 31
 error.date.month_blank = Enter a month
 error.date.month_invalid = Give a correct month using numbers 1 to 12
 error.date.year_blank = Enter a year
+error.date.year_invalid = Give a correct year
 error.date.year_invalid = Give a correct year
 error.integer = Give an answer in whole numbers
 error.non_numeric = Give a value using only numbers

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -109,3 +109,8 @@ inheritanceTaxAct.title = Are you registering the trust for purpose of Section 2
 inheritanceTaxAct.heading = Are you registering the trust for purpose of Section 218 Inheritance Tax Act 1984?
 inheritanceTaxAct.checkYourAnswersLabel = inheritanceTaxAct
 inheritanceTaxAct.error.required = Select yes if inheritanceTaxAct
+
+agentOtherThanBarrister.title = Has an agent, other than a barrister, created the non-UK resident trust being registered
+agentOtherThanBarrister.heading = Has an agent, other than a barrister, created the non-UK resident trust being registered?
+agentOtherThanBarrister.checkYourAnswersLabel = agentOtherThanBarrister
+agentOtherThanBarrister.error.required = Select yes if agentOtherThanBarrister

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -36,9 +36,15 @@ site.hidden-delete = Delete {0}
 site.hidden-edit = Change {0}
 site.no = No
 site.yes = Yes
-site.continue = Continue
+site.continue = Save and continue
 site.service_name = Trusts Registration Service
 site.textarea.char_limit = (Limit is {0} characters)
 
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
+
+trustName.title = What is the name of the trust
+trustName.heading = What is the name of the trust?
+trustName.checkYourAnswersLabel = trustName
+trustName.error.required = Enter trustName
+trustName.error.length = TrustName must be 53 characters or less

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -59,3 +59,8 @@ countryGoverningTrust.heading = What is the country governing the trust?
 countryGoverningTrust.checkYourAnswersLabel = countryGoverningTrust
 countryGoverningTrust.error.required = Enter countryGoverningTrust
 countryGoverningTrust.error.length = CountryGoverningTrust must be 100 characters or less
+
+administrationOutsideUK.title = Is the trust's general administration done outside the UK
+administrationOutsideUK.heading = Is the trust's general administration done outside the UK?
+administrationOutsideUK.checkYourAnswersLabel = administrationOutsideUK
+administrationOutsideUK.error.required = Select yes if administrationOutsideUK

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -75,3 +75,13 @@ trustResidentInUK.title = Is the trust resident in the UK
 trustResidentInUK.heading = Is the trust resident in the UK?
 trustResidentInUK.checkYourAnswersLabel = trustResidentInUK
 trustResidentInUK.error.required = Select yes if trustResidentInUK
+
+establishedUnderScotsLaw.title = Is the trust established under Scots law
+establishedUnderScotsLaw.heading = Is the trust established under Scots law?
+establishedUnderScotsLaw.checkYourAnswersLabel = establishedUnderScotsLaw
+establishedUnderScotsLaw.error.required = Select yes if establishedUnderScotsLaw
+
+registeringTrustFor5A.title = Are you registering trust for the purpose of Schedule 5A Taxation of Chargeable Gains Act 1992
+registeringTrustFor5A.heading = Are you registering trust for the purpose of Schedule 5A Taxation of Chargeable Gains Act 1992?
+registeringTrustFor5A.checkYourAnswersLabel = registeringTrustFor5A
+registeringTrustFor5A.error.required = Select yes if registeringTrustFor5A

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -53,3 +53,9 @@ governedOutsideTheUK.title = Is the trust governed by the laws of a country outs
 governedOutsideTheUK.heading = Is the trust governed by the laws of a country outside the UK?
 governedOutsideTheUK.checkYourAnswersLabel = governedOutsideTheUK
 governedOutsideTheUK.error.required = Select yes if governedOutsideTheUK
+
+countryGoverningTrust.title = What is the country governing the trust
+countryGoverningTrust.heading = What is the country governing the trust?
+countryGoverningTrust.checkYourAnswersLabel = countryGoverningTrust
+countryGoverningTrust.error.required = Enter countryGoverningTrust
+countryGoverningTrust.error.length = CountryGoverningTrust must be 100 characters or less

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -114,3 +114,11 @@ agentOtherThanBarrister.title = Has an agent, other than a barrister, created th
 agentOtherThanBarrister.heading = Has an agent, other than a barrister, created the non-UK resident trust being registered?
 agentOtherThanBarrister.checkYourAnswersLabel = agentOtherThanBarrister
 agentOtherThanBarrister.error.required = Select yes if agentOtherThanBarrister
+
+whenTrustSetup.title = WhenTrustSetup
+whenTrustSetup.heading = WhenTrustSetup
+whenTrustSetup.checkYourAnswersLabel = WhenTrustSetup
+whenTrustSetup.error.required.all = Enter the whenTrustSetup
+whenTrustSetup.error.required.two = The whenTrustSetup must include {0} and {1}
+whenTrustSetup.error.required = The whenTrustSetup must include {0}
+whenTrustSetup.error.invalid = Enter a real WhenTrustSetup

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -48,3 +48,8 @@ trustName.heading = What is the name of the trust?
 trustName.checkYourAnswersLabel = trustName
 trustName.error.required = Enter trustName
 trustName.error.length = TrustName must be 53 characters or less
+
+governedOutsideTheUK.title = Is the trust governed by the laws of a country outside the UK
+governedOutsideTheUK.heading = Is the trust governed by the laws of a country outside the UK?
+governedOutsideTheUK.checkYourAnswersLabel = governedOutsideTheUK
+governedOutsideTheUK.error.required = Select yes if governedOutsideTheUK

--- a/migrations/applied_migrations/AdministrationOutsideUK.sh
+++ b/migrations/applied_migrations/AdministrationOutsideUK.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration AdministrationOutsideUK"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /administrationOutsideUK                        controllers.AdministrationOutsideUKController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /administrationOutsideUK                        controllers.AdministrationOutsideUKController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeAdministrationOutsideUK                  controllers.AdministrationOutsideUKController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeAdministrationOutsideUK                  controllers.AdministrationOutsideUKController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "administrationOutsideUK.title = administrationOutsideUK" >> ../conf/messages.en
+echo "administrationOutsideUK.heading = administrationOutsideUK" >> ../conf/messages.en
+echo "administrationOutsideUK.checkYourAnswersLabel = administrationOutsideUK" >> ../conf/messages.en
+echo "administrationOutsideUK.error.required = Select yes if administrationOutsideUK" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryAdministrationOutsideUKUserAnswersEntry: Arbitrary[(AdministrationOutsideUKPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[AdministrationOutsideUKPage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryAdministrationOutsideUKPage: Arbitrary[AdministrationOutsideUKPage.type] =";\
+    print "    Arbitrary(AdministrationOutsideUKPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(AdministrationOutsideUKPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def administrationOutsideUK: Option[AnswerRow] = userAnswers.get(AdministrationOutsideUKPage) map {";\
+     print "    x => AnswerRow(\"administrationOutsideUK.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.AdministrationOutsideUKController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration AdministrationOutsideUK completed"

--- a/migrations/applied_migrations/AgentOtherThanBarrister.sh
+++ b/migrations/applied_migrations/AgentOtherThanBarrister.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration AgentOtherThanBarrister"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /agentOtherThanBarrister                        controllers.AgentOtherThanBarristerController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /agentOtherThanBarrister                        controllers.AgentOtherThanBarristerController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeAgentOtherThanBarrister                  controllers.AgentOtherThanBarristerController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeAgentOtherThanBarrister                  controllers.AgentOtherThanBarristerController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "agentOtherThanBarrister.title = agentOtherThanBarrister" >> ../conf/messages.en
+echo "agentOtherThanBarrister.heading = agentOtherThanBarrister" >> ../conf/messages.en
+echo "agentOtherThanBarrister.checkYourAnswersLabel = agentOtherThanBarrister" >> ../conf/messages.en
+echo "agentOtherThanBarrister.error.required = Select yes if agentOtherThanBarrister" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryAgentOtherThanBarristerUserAnswersEntry: Arbitrary[(AgentOtherThanBarristerPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[AgentOtherThanBarristerPage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryAgentOtherThanBarristerPage: Arbitrary[AgentOtherThanBarristerPage.type] =";\
+    print "    Arbitrary(AgentOtherThanBarristerPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(AgentOtherThanBarristerPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def agentOtherThanBarrister: Option[AnswerRow] = userAnswers.get(AgentOtherThanBarristerPage) map {";\
+     print "    x => AnswerRow(\"agentOtherThanBarrister.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.AgentOtherThanBarristerController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration AgentOtherThanBarrister completed"

--- a/migrations/applied_migrations/CountryAdministeringTrust.sh
+++ b/migrations/applied_migrations/CountryAdministeringTrust.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration CountryAdministeringTrust"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /countryAdministeringTrust                        controllers.CountryAdministeringTrustController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /countryAdministeringTrust                        controllers.CountryAdministeringTrustController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeCountryAdministeringTrust                  controllers.CountryAdministeringTrustController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeCountryAdministeringTrust                  controllers.CountryAdministeringTrustController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "countryAdministeringTrust.title = countryAdministeringTrust" >> ../conf/messages.en
+echo "countryAdministeringTrust.heading = countryAdministeringTrust" >> ../conf/messages.en
+echo "countryAdministeringTrust.checkYourAnswersLabel = countryAdministeringTrust" >> ../conf/messages.en
+echo "countryAdministeringTrust.error.required = Enter countryAdministeringTrust" >> ../conf/messages.en
+echo "countryAdministeringTrust.error.length = CountryAdministeringTrust must be 100 characters or less" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryCountryAdministeringTrustUserAnswersEntry: Arbitrary[(CountryAdministeringTrustPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[CountryAdministeringTrustPage.type]";\
+    print "        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryCountryAdministeringTrustPage: Arbitrary[CountryAdministeringTrustPage.type] =";\
+    print "    Arbitrary(CountryAdministeringTrustPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(CountryAdministeringTrustPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def countryAdministeringTrust: Option[AnswerRow] = userAnswers.get(CountryAdministeringTrustPage) map {";\
+     print "    x => AnswerRow(\"countryAdministeringTrust.checkYourAnswersLabel\", s\"$x\", false, routes.CountryAdministeringTrustController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration CountryAdministeringTrust completed"

--- a/migrations/applied_migrations/CountryGoverningTrust.sh
+++ b/migrations/applied_migrations/CountryGoverningTrust.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration CountryGoverningTrust"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /countryGoverningTrust                        controllers.CountryGoverningTrustController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /countryGoverningTrust                        controllers.CountryGoverningTrustController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeCountryGoverningTrust                  controllers.CountryGoverningTrustController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeCountryGoverningTrust                  controllers.CountryGoverningTrustController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "countryGoverningTrust.title = countryGoverningTrust" >> ../conf/messages.en
+echo "countryGoverningTrust.heading = countryGoverningTrust" >> ../conf/messages.en
+echo "countryGoverningTrust.checkYourAnswersLabel = countryGoverningTrust" >> ../conf/messages.en
+echo "countryGoverningTrust.error.required = Enter countryGoverningTrust" >> ../conf/messages.en
+echo "countryGoverningTrust.error.length = CountryGoverningTrust must be 100 characters or less" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryCountryGoverningTrustUserAnswersEntry: Arbitrary[(CountryGoverningTrustPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[CountryGoverningTrustPage.type]";\
+    print "        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryCountryGoverningTrustPage: Arbitrary[CountryGoverningTrustPage.type] =";\
+    print "    Arbitrary(CountryGoverningTrustPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(CountryGoverningTrustPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def countryGoverningTrust: Option[AnswerRow] = userAnswers.get(CountryGoverningTrustPage) map {";\
+     print "    x => AnswerRow(\"countryGoverningTrust.checkYourAnswersLabel\", s\"$x\", false, routes.CountryGoverningTrustController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration CountryGoverningTrust completed"

--- a/migrations/applied_migrations/EstablishedUnderScotsLaw.sh
+++ b/migrations/applied_migrations/EstablishedUnderScotsLaw.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration EstablishedUnderScotsLaw"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /establishedUnderScotsLaw                        controllers.EstablishedUnderScotsLawController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /establishedUnderScotsLaw                        controllers.EstablishedUnderScotsLawController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeEstablishedUnderScotsLaw                  controllers.EstablishedUnderScotsLawController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeEstablishedUnderScotsLaw                  controllers.EstablishedUnderScotsLawController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "establishedUnderScotsLaw.title = establishedUnderScotsLaw" >> ../conf/messages.en
+echo "establishedUnderScotsLaw.heading = establishedUnderScotsLaw" >> ../conf/messages.en
+echo "establishedUnderScotsLaw.checkYourAnswersLabel = establishedUnderScotsLaw" >> ../conf/messages.en
+echo "establishedUnderScotsLaw.error.required = Select yes if establishedUnderScotsLaw" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryEstablishedUnderScotsLawUserAnswersEntry: Arbitrary[(EstablishedUnderScotsLawPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[EstablishedUnderScotsLawPage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryEstablishedUnderScotsLawPage: Arbitrary[EstablishedUnderScotsLawPage.type] =";\
+    print "    Arbitrary(EstablishedUnderScotsLawPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(EstablishedUnderScotsLawPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def establishedUnderScotsLaw: Option[AnswerRow] = userAnswers.get(EstablishedUnderScotsLawPage) map {";\
+     print "    x => AnswerRow(\"establishedUnderScotsLaw.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.EstablishedUnderScotsLawController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration EstablishedUnderScotsLaw completed"

--- a/migrations/applied_migrations/GovernedOutsideTheUK.sh
+++ b/migrations/applied_migrations/GovernedOutsideTheUK.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration GovernedOutsideTheUK"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /governedOutsideTheUK                        controllers.GovernedOutsideTheUKController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /governedOutsideTheUK                        controllers.GovernedOutsideTheUKController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeGovernedOutsideTheUK                  controllers.GovernedOutsideTheUKController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeGovernedOutsideTheUK                  controllers.GovernedOutsideTheUKController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "governedOutsideTheUK.title = governedOutsideTheUK" >> ../conf/messages.en
+echo "governedOutsideTheUK.heading = governedOutsideTheUK" >> ../conf/messages.en
+echo "governedOutsideTheUK.checkYourAnswersLabel = governedOutsideTheUK" >> ../conf/messages.en
+echo "governedOutsideTheUK.error.required = Select yes if governedOutsideTheUK" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryGovernedOutsideTheUKUserAnswersEntry: Arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[GovernedOutsideTheUKPage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryGovernedOutsideTheUKPage: Arbitrary[GovernedOutsideTheUKPage.type] =";\
+    print "    Arbitrary(GovernedOutsideTheUKPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def governedOutsideTheUK: Option[AnswerRow] = userAnswers.get(GovernedOutsideTheUKPage) map {";\
+     print "    x => AnswerRow(\"governedOutsideTheUK.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.GovernedOutsideTheUKController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration GovernedOutsideTheUK completed"

--- a/migrations/applied_migrations/InheritanceTaxAct.sh
+++ b/migrations/applied_migrations/InheritanceTaxAct.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration InheritanceTaxAct"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /inheritanceTaxAct                        controllers.InheritanceTaxActController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /inheritanceTaxAct                        controllers.InheritanceTaxActController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeInheritanceTaxAct                  controllers.InheritanceTaxActController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeInheritanceTaxAct                  controllers.InheritanceTaxActController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "inheritanceTaxAct.title = inheritanceTaxAct" >> ../conf/messages.en
+echo "inheritanceTaxAct.heading = inheritanceTaxAct" >> ../conf/messages.en
+echo "inheritanceTaxAct.checkYourAnswersLabel = inheritanceTaxAct" >> ../conf/messages.en
+echo "inheritanceTaxAct.error.required = Select yes if inheritanceTaxAct" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryInheritanceTaxActUserAnswersEntry: Arbitrary[(InheritanceTaxActPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[InheritanceTaxActPage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryInheritanceTaxActPage: Arbitrary[InheritanceTaxActPage.type] =";\
+    print "    Arbitrary(InheritanceTaxActPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(InheritanceTaxActPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def inheritanceTaxAct: Option[AnswerRow] = userAnswers.get(InheritanceTaxActPage) map {";\
+     print "    x => AnswerRow(\"inheritanceTaxAct.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.InheritanceTaxActController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration InheritanceTaxAct completed"

--- a/migrations/applied_migrations/Non_residentType.sh
+++ b/migrations/applied_migrations/Non_residentType.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration Non_residentType"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /non-residentType                        controllers.Non-residentTypeController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /non-residentType                        controllers.Non-residentTypeController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeNon-residentType                  controllers.Non-residentTypeController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeNon-residentType                  controllers.Non-residentTypeController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "non-residentType.title = What is the non-resident type" >> ../conf/messages.en
+echo "non-residentType.heading = What is the non-resident type" >> ../conf/messages.en
+echo "non-residentType.1 = Settlor domiciled trustees are non-resident" >> ../conf/messages.en
+echo "non-residentType.2 = Settlor non-domiciled becomes domiciled then resident" >> ../conf/messages.en
+echo "non-residentType.checkYourAnswersLabel = What is the non-resident type" >> ../conf/messages.en
+echo "non-residentType.error.required = Select non-residentType" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryNon-residentTypeUserAnswersEntry: Arbitrary[(Non-residentTypePage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[Non-residentTypePage.type]";\
+    print "        value <- arbitrary[Non-residentType].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryNon-residentTypePage: Arbitrary[Non-residentTypePage.type] =";\
+    print "    Arbitrary(Non-residentTypePage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to ModelGenerators"
+awk '/trait ModelGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryNon-residentType: Arbitrary[Non-residentType] =";\
+    print "    Arbitrary {";\
+    print "      Gen.oneOf(Non-residentType.values.toSeq)";\
+    print "    }";\
+    next }1' ../test/generators/ModelGenerators.scala > tmp && mv tmp ../test/generators/ModelGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(Non-residentTypePage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def non-residentType: Option[AnswerRow] = userAnswers.get(Non-residentTypePage) map {";\
+     print "    x => AnswerRow(\"non-residentType.checkYourAnswersLabel\", s\"non-residentType.$x\", true, routes.Non-residentTypeController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration Non_residentType completed"

--- a/migrations/applied_migrations/RegisteringTrustFor5A.sh
+++ b/migrations/applied_migrations/RegisteringTrustFor5A.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration RegisteringTrustFor5A"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /registeringTrustFor5A                        controllers.RegisteringTrustFor5AController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /registeringTrustFor5A                        controllers.RegisteringTrustFor5AController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeRegisteringTrustFor5A                  controllers.RegisteringTrustFor5AController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeRegisteringTrustFor5A                  controllers.RegisteringTrustFor5AController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "registeringTrustFor5A.title = registeringTrustFor5A" >> ../conf/messages.en
+echo "registeringTrustFor5A.heading = registeringTrustFor5A" >> ../conf/messages.en
+echo "registeringTrustFor5A.checkYourAnswersLabel = registeringTrustFor5A" >> ../conf/messages.en
+echo "registeringTrustFor5A.error.required = Select yes if registeringTrustFor5A" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryRegisteringTrustFor5AUserAnswersEntry: Arbitrary[(RegisteringTrustFor5APage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[RegisteringTrustFor5APage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryRegisteringTrustFor5APage: Arbitrary[RegisteringTrustFor5APage.type] =";\
+    print "    Arbitrary(RegisteringTrustFor5APage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(RegisteringTrustFor5APage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def registeringTrustFor5A: Option[AnswerRow] = userAnswers.get(RegisteringTrustFor5APage) map {";\
+     print "    x => AnswerRow(\"registeringTrustFor5A.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.RegisteringTrustFor5AController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration RegisteringTrustFor5A completed"

--- a/migrations/applied_migrations/TrustName.sh
+++ b/migrations/applied_migrations/TrustName.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration TrustName"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /trustName                        controllers.TrustNameController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /trustName                        controllers.TrustNameController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeTrustName                  controllers.TrustNameController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeTrustName                  controllers.TrustNameController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "trustName.title = trustName" >> ../conf/messages.en
+echo "trustName.heading = trustName" >> ../conf/messages.en
+echo "trustName.checkYourAnswersLabel = trustName" >> ../conf/messages.en
+echo "trustName.error.required = Enter trustName" >> ../conf/messages.en
+echo "trustName.error.length = TrustName must be 53 characters or less" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustNameUserAnswersEntry: Arbitrary[(TrustNamePage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[TrustNamePage.type]";\
+    print "        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustNamePage: Arbitrary[TrustNamePage.type] =";\
+    print "    Arbitrary(TrustNamePage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(TrustNamePage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def trustName: Option[AnswerRow] = userAnswers.get(TrustNamePage) map {";\
+     print "    x => AnswerRow(\"trustName.checkYourAnswersLabel\", s\"$x\", false, routes.TrustNameController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration TrustName completed"

--- a/migrations/applied_migrations/TrustPreviouslyResident.sh
+++ b/migrations/applied_migrations/TrustPreviouslyResident.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration TrustPreviouslyResident"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /trustPreviouslyResident                        controllers.TrustPreviouslyResidentController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /trustPreviouslyResident                        controllers.TrustPreviouslyResidentController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeTrustPreviouslyResident                  controllers.TrustPreviouslyResidentController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeTrustPreviouslyResident                  controllers.TrustPreviouslyResidentController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "trustPreviouslyResident.title = trustPreviouslyResident" >> ../conf/messages.en
+echo "trustPreviouslyResident.heading = trustPreviouslyResident" >> ../conf/messages.en
+echo "trustPreviouslyResident.checkYourAnswersLabel = trustPreviouslyResident" >> ../conf/messages.en
+echo "trustPreviouslyResident.error.required = Enter trustPreviouslyResident" >> ../conf/messages.en
+echo "trustPreviouslyResident.error.length = TrustPreviouslyResident must be 100 characters or less" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustPreviouslyResidentUserAnswersEntry: Arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[TrustPreviouslyResidentPage.type]";\
+    print "        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustPreviouslyResidentPage: Arbitrary[TrustPreviouslyResidentPage.type] =";\
+    print "    Arbitrary(TrustPreviouslyResidentPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def trustPreviouslyResident: Option[AnswerRow] = userAnswers.get(TrustPreviouslyResidentPage) map {";\
+     print "    x => AnswerRow(\"trustPreviouslyResident.checkYourAnswersLabel\", s\"$x\", false, routes.TrustPreviouslyResidentController.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration TrustPreviouslyResident completed"

--- a/migrations/applied_migrations/TrustResidentInUK.sh
+++ b/migrations/applied_migrations/TrustResidentInUK.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration TrustResidentInUK"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /trustResidentInUK                        controllers.TrustResidentInUKController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /trustResidentInUK                        controllers.TrustResidentInUKController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeTrustResidentInUK                  controllers.TrustResidentInUKController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeTrustResidentInUK                  controllers.TrustResidentInUKController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "trustResidentInUK.title = trustResidentInUK" >> ../conf/messages.en
+echo "trustResidentInUK.heading = trustResidentInUK" >> ../conf/messages.en
+echo "trustResidentInUK.checkYourAnswersLabel = trustResidentInUK" >> ../conf/messages.en
+echo "trustResidentInUK.error.required = Select yes if trustResidentInUK" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustResidentInUKUserAnswersEntry: Arbitrary[(TrustResidentInUKPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[TrustResidentInUKPage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustResidentInUKPage: Arbitrary[TrustResidentInUKPage.type] =";\
+    print "    Arbitrary(TrustResidentInUKPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(TrustResidentInUKPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def trustResidentInUK: Option[AnswerRow] = userAnswers.get(TrustResidentInUKPage) map {";\
+     print "    x => AnswerRow(\"trustResidentInUK.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.TrustResidentInUKController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration TrustResidentInUK completed"

--- a/migrations/applied_migrations/TrustResidentOffshore.sh
+++ b/migrations/applied_migrations/TrustResidentOffshore.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration TrustResidentOffshore"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /trustResidentOffshore                        controllers.TrustResidentOffshoreController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /trustResidentOffshore                        controllers.TrustResidentOffshoreController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeTrustResidentOffshore                  controllers.TrustResidentOffshoreController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeTrustResidentOffshore                  controllers.TrustResidentOffshoreController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "trustResidentOffshore.title = trustResidentOffshore" >> ../conf/messages.en
+echo "trustResidentOffshore.heading = trustResidentOffshore" >> ../conf/messages.en
+echo "trustResidentOffshore.checkYourAnswersLabel = trustResidentOffshore" >> ../conf/messages.en
+echo "trustResidentOffshore.error.required = Select yes if trustResidentOffshore" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustResidentOffshoreUserAnswersEntry: Arbitrary[(TrustResidentOffshorePage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[TrustResidentOffshorePage.type]";\
+    print "        value <- arbitrary[Boolean].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryTrustResidentOffshorePage: Arbitrary[TrustResidentOffshorePage.type] =";\
+    print "    Arbitrary(TrustResidentOffshorePage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(TrustResidentOffshorePage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def trustResidentOffshore: Option[AnswerRow] = userAnswers.get(TrustResidentOffshorePage) map {";\
+     print "    x => AnswerRow(\"trustResidentOffshore.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.TrustResidentOffshoreController.onPageLoad(CheckMode).url)"; print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration TrustResidentOffshore completed"

--- a/migrations/applied_migrations/WhenTrustSetup.sh
+++ b/migrations/applied_migrations/WhenTrustSetup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+echo ""
+echo "Applying migration WhenTrustSetup"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /whenTrustSetup                  controllers.WhenTrustSetupController.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /whenTrustSetup                  controllers.WhenTrustSetupController.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /changeWhenTrustSetup                        controllers.WhenTrustSetupController.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /changeWhenTrustSetup                        controllers.WhenTrustSetupController.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "whenTrustSetup.title = WhenTrustSetup" >> ../conf/messages.en
+echo "whenTrustSetup.heading = WhenTrustSetup" >> ../conf/messages.en
+echo "whenTrustSetup.checkYourAnswersLabel = WhenTrustSetup" >> ../conf/messages.en
+echo "whenTrustSetup.error.required.all = Enter the whenTrustSetup" >> ../conf/messages.en
+echo "whenTrustSetup.error.required.two = The whenTrustSetup" must include {0} and {1} >> ../conf/messages.en
+echo "whenTrustSetup.error.required = The whenTrustSetup must include {0}" >> ../conf/messages.en
+echo "whenTrustSetup.error.invalid = Enter a real WhenTrustSetup" >> ../conf/messages.en
+
+echo "Adding to UserAnswersEntryGenerators"
+awk '/trait UserAnswersEntryGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryWhenTrustSetupUserAnswersEntry: Arbitrary[(WhenTrustSetupPage.type, JsValue)] =";\
+    print "    Arbitrary {";\
+    print "      for {";\
+    print "        page  <- arbitrary[WhenTrustSetupPage.type]";\
+    print "        value <- arbitrary[Int].map(Json.toJson(_))";\
+    print "      } yield (page, value)";\
+    print "    }";\
+    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+
+echo "Adding to PageGenerators"
+awk '/trait PageGenerators/ {\
+    print;\
+    print "";\
+    print "  implicit lazy val arbitraryWhenTrustSetupPage: Arbitrary[WhenTrustSetupPage.type] =";\
+    print "    Arbitrary(WhenTrustSetupPage)";\
+    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+
+echo "Adding to UserAnswersGenerator"
+awk '/val generators/ {\
+    print;\
+    print "    arbitrary[(WhenTrustSetupPage.type, JsValue)] ::";\
+    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def whenTrustSetup: Option[AnswerRow] = userAnswers.get(WhenTrustSetupPage) map {";\
+     print "    x =>";\
+     print "      AnswerRow(";\
+     print "        \"whenTrustSetup.checkYourAnswersLabel\",";\
+     print "        HtmlFormat.escape(x.format(dateFormatter)),";\
+     print "        routes.WhenTrustSetupController.onPageLoad(CheckMode).url";\
+     print "      )";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Migration WhenTrustSetup completed"

--- a/test/controllers/AdministrationOutsideUKControllerSpec.scala
+++ b/test/controllers/AdministrationOutsideUKControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/AdministrationOutsideUKControllerSpec.scala
+++ b/test/controllers/AdministrationOutsideUKControllerSpec.scala
@@ -53,6 +53,8 @@ class AdministrationOutsideUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class AdministrationOutsideUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class AdministrationOutsideUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class AdministrationOutsideUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class AdministrationOutsideUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class AdministrationOutsideUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/AdministrationOutsideUKControllerSpec.scala
+++ b/test/controllers/AdministrationOutsideUKControllerSpec.scala
@@ -1,0 +1,126 @@
+package controllers
+
+import base.SpecBase
+import forms.AdministrationOutsideUKFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.AdministrationOutsideUKPage
+import play.api.inject.bind
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.AdministrationOutsideUKView
+
+class AdministrationOutsideUKControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new AdministrationOutsideUKFormProvider()
+  val form = formProvider()
+
+  lazy val administrationOutsideUKRoute = routes.AdministrationOutsideUKController.onPageLoad(NormalMode).url
+
+  "AdministrationOutsideUK Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, administrationOutsideUKRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[AdministrationOutsideUKView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(AdministrationOutsideUKPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, administrationOutsideUKRoute)
+
+      val view = application.injector.instanceOf[AdministrationOutsideUKView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, administrationOutsideUKRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, administrationOutsideUKRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[AdministrationOutsideUKView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, administrationOutsideUKRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, administrationOutsideUKRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/AgentOtherThanBarristerControllerSpec.scala
+++ b/test/controllers/AgentOtherThanBarristerControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/AgentOtherThanBarristerControllerSpec.scala
+++ b/test/controllers/AgentOtherThanBarristerControllerSpec.scala
@@ -1,53 +1,37 @@
-/*
- * Copyright 2018 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package controllers
 
 import base.SpecBase
-import forms.NonResidentTypeFormProvider
-import models.{NormalMode, NonResidentType, UserAnswers}
+import forms.AgentOtherThanBarristerFormProvider
+import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import pages.NonResidentTypePage
+import pages.AgentOtherThanBarristerPage
 import play.api.inject.bind
-import play.api.libs.json.{JsString, Json}
+import play.api.libs.json.{JsBoolean, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import views.html.NonResidentTypeView
+import views.html.AgentOtherThanBarristerView
 
-class NonResidentTypeControllerSpec extends SpecBase {
+class AgentOtherThanBarristerControllerSpec extends SpecBase {
 
   def onwardRoute = Call("GET", "/foo")
 
-  lazy val nonresidentTypeRoute = routes.NonResidentTypeController.onPageLoad(NormalMode).url
-
-  val formProvider = new NonResidentTypeFormProvider()
+  val formProvider = new AgentOtherThanBarristerFormProvider()
   val form = formProvider()
 
-  "Non-residentType Controller" must {
+  lazy val agentOtherThanBarristerRoute = routes.AgentOtherThanBarristerController.onPageLoad(NormalMode).url
+
+  "AgentOtherThanBarrister Controller" must {
 
     "return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val request = FakeRequest(GET, nonresidentTypeRoute)
+      val request = FakeRequest(GET, agentOtherThanBarristerRoute)
 
       val result = route(application, request).value
 
-      val view = application.injector.instanceOf[NonResidentTypeView]
+      val view = application.injector.instanceOf[AgentOtherThanBarristerView]
 
       status(result) mustEqual OK
 
@@ -57,20 +41,20 @@ class NonResidentTypeControllerSpec extends SpecBase {
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(NonResidentTypePage, NonResidentType.values.head).success.value
+      val userAnswers = UserAnswers(userAnswersId).set(AgentOtherThanBarristerPage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, nonresidentTypeRoute)
+      val request = FakeRequest(GET, agentOtherThanBarristerRoute)
 
-      val view = application.injector.instanceOf[NonResidentTypeView]
+      val view = application.injector.instanceOf[AgentOtherThanBarristerView]
 
       val result = route(application, request).value
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(NonResidentType.values.head), NormalMode)(fakeRequest, messages).toString
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -81,8 +65,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
           .build()
 
       val request =
-        FakeRequest(POST, nonresidentTypeRoute)
-          .withFormUrlEncodedBody(("value", NonResidentType.options.head.value))
+        FakeRequest(POST, agentOtherThanBarristerRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
 
@@ -96,12 +80,12 @@ class NonResidentTypeControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request =
-        FakeRequest(POST, nonresidentTypeRoute)
-          .withFormUrlEncodedBody(("value", "invalid value"))
+        FakeRequest(POST, agentOtherThanBarristerRoute)
+          .withFormUrlEncodedBody(("value", ""))
 
-      val boundForm = form.bind(Map("value" -> "invalid value"))
+      val boundForm = form.bind(Map("value" -> ""))
 
-      val view = application.injector.instanceOf[NonResidentTypeView]
+      val view = application.injector.instanceOf[AgentOtherThanBarristerView]
 
       val result = route(application, request).value
 
@@ -115,11 +99,12 @@ class NonResidentTypeControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request = FakeRequest(GET, nonresidentTypeRoute)
+      val request = FakeRequest(GET, agentOtherThanBarristerRoute)
 
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
+
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
     }
 
@@ -128,8 +113,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       val request =
-        FakeRequest(POST, nonresidentTypeRoute)
-          .withFormUrlEncodedBody(("value", NonResidentType.values.head.toString))
+        FakeRequest(POST, agentOtherThanBarristerRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
 

--- a/test/controllers/AgentOtherThanBarristerControllerSpec.scala
+++ b/test/controllers/AgentOtherThanBarristerControllerSpec.scala
@@ -53,6 +53,8 @@ class AgentOtherThanBarristerControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class AgentOtherThanBarristerControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class AgentOtherThanBarristerControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class AgentOtherThanBarristerControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class AgentOtherThanBarristerControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class AgentOtherThanBarristerControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -40,6 +40,8 @@ class CheckYourAnswersControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(Seq(AnswerSection(None, Seq())))(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -53,6 +55,8 @@ class CheckYourAnswersControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/CountryAdministeringTrustControllerSpec.scala
+++ b/test/controllers/CountryAdministeringTrustControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/CountryAdministeringTrustControllerSpec.scala
+++ b/test/controllers/CountryAdministeringTrustControllerSpec.scala
@@ -53,6 +53,8 @@ class CountryAdministeringTrustControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class CountryAdministeringTrustControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -88,6 +92,8 @@ class CountryAdministeringTrustControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -108,6 +114,8 @@ class CountryAdministeringTrustControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -121,6 +129,8 @@ class CountryAdministeringTrustControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -136,6 +146,8 @@ class CountryAdministeringTrustControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/CountryAdministeringTrustControllerSpec.scala
+++ b/test/controllers/CountryAdministeringTrustControllerSpec.scala
@@ -1,53 +1,37 @@
-/*
- * Copyright 2018 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package controllers
 
 import base.SpecBase
-import forms.TrustNameFormProvider
+import forms.CountryAdministeringTrustFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import pages.TrustNamePage
+import pages.CountryAdministeringTrustPage
 import play.api.inject.bind
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import views.html.TrustNameView
+import views.html.CountryAdministeringTrustView
 
-class TrustNameControllerSpec extends SpecBase {
+class CountryAdministeringTrustControllerSpec extends SpecBase {
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new TrustNameFormProvider()
+  val formProvider = new CountryAdministeringTrustFormProvider()
   val form = formProvider()
 
-  lazy val trustNameRoute = routes.TrustNameController.onPageLoad(NormalMode).url
+  lazy val countryAdministeringTrustRoute = routes.CountryAdministeringTrustController.onPageLoad(NormalMode).url
 
-  "TrustName Controller" must {
+  "CountryAdministeringTrust Controller" must {
 
     "return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val request = FakeRequest(GET, trustNameRoute)
+      val request = FakeRequest(GET, countryAdministeringTrustRoute)
 
       val result = route(application, request).value
 
-      val view = application.injector.instanceOf[TrustNameView]
+      val view = application.injector.instanceOf[CountryAdministeringTrustView]
 
       status(result) mustEqual OK
 
@@ -57,13 +41,13 @@ class TrustNameControllerSpec extends SpecBase {
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(TrustNamePage, "answer").success.value
+      val userAnswers = UserAnswers(userAnswersId).set(CountryAdministeringTrustPage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, trustNameRoute)
+      val request = FakeRequest(GET, countryAdministeringTrustRoute)
 
-      val view = application.injector.instanceOf[TrustNameView]
+      val view = application.injector.instanceOf[CountryAdministeringTrustView]
 
       val result = route(application, request).value
 
@@ -81,7 +65,7 @@ class TrustNameControllerSpec extends SpecBase {
           .build()
 
       val request =
-        FakeRequest(POST, trustNameRoute)
+        FakeRequest(POST, countryAdministeringTrustRoute)
           .withFormUrlEncodedBody(("value", "answer"))
 
       val result = route(application, request).value
@@ -95,12 +79,12 @@ class TrustNameControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request =
-        FakeRequest(POST, trustNameRoute)
+        FakeRequest(POST, countryAdministeringTrustRoute)
           .withFormUrlEncodedBody(("value", ""))
 
       val boundForm = form.bind(Map("value" -> ""))
 
-      val view = application.injector.instanceOf[TrustNameView]
+      val view = application.injector.instanceOf[CountryAdministeringTrustView]
 
       val result = route(application, request).value
 
@@ -114,7 +98,7 @@ class TrustNameControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request = FakeRequest(GET, trustNameRoute)
+      val request = FakeRequest(GET, countryAdministeringTrustRoute)
 
       val result = route(application, request).value
 
@@ -128,7 +112,7 @@ class TrustNameControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       val request =
-        FakeRequest(POST, trustNameRoute)
+        FakeRequest(POST, countryAdministeringTrustRoute)
           .withFormUrlEncodedBody(("value", "answer"))
 
       val result = route(application, request).value

--- a/test/controllers/CountryGoverningTrustControllerSpec.scala
+++ b/test/controllers/CountryGoverningTrustControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/CountryGoverningTrustControllerSpec.scala
+++ b/test/controllers/CountryGoverningTrustControllerSpec.scala
@@ -1,0 +1,125 @@
+package controllers
+
+import base.SpecBase
+import forms.CountryGoverningTrustFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.CountryGoverningTrustPage
+import play.api.inject.bind
+import play.api.libs.json.{JsString, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.CountryGoverningTrustView
+
+class CountryGoverningTrustControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new CountryGoverningTrustFormProvider()
+  val form = formProvider()
+
+  lazy val countryGoverningTrustRoute = routes.CountryGoverningTrustController.onPageLoad(NormalMode).url
+
+  "CountryGoverningTrust Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, countryGoverningTrustRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[CountryGoverningTrustView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(CountryGoverningTrustPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, countryGoverningTrustRoute)
+
+      val view = application.injector.instanceOf[CountryGoverningTrustView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, countryGoverningTrustRoute)
+          .withFormUrlEncodedBody(("value", "answer"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, countryGoverningTrustRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[CountryGoverningTrustView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, countryGoverningTrustRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, countryGoverningTrustRoute)
+          .withFormUrlEncodedBody(("value", "answer"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/CountryGoverningTrustControllerSpec.scala
+++ b/test/controllers/CountryGoverningTrustControllerSpec.scala
@@ -53,6 +53,8 @@ class CountryGoverningTrustControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class CountryGoverningTrustControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -88,6 +92,8 @@ class CountryGoverningTrustControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -108,6 +114,8 @@ class CountryGoverningTrustControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -121,6 +129,8 @@ class CountryGoverningTrustControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -136,6 +146,8 @@ class CountryGoverningTrustControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/EstablishedUnderScotsLawControllerSpec.scala
+++ b/test/controllers/EstablishedUnderScotsLawControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/EstablishedUnderScotsLawControllerSpec.scala
+++ b/test/controllers/EstablishedUnderScotsLawControllerSpec.scala
@@ -53,6 +53,8 @@ class EstablishedUnderScotsLawControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class EstablishedUnderScotsLawControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class EstablishedUnderScotsLawControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class EstablishedUnderScotsLawControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class EstablishedUnderScotsLawControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class EstablishedUnderScotsLawControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/EstablishedUnderScotsLawControllerSpec.scala
+++ b/test/controllers/EstablishedUnderScotsLawControllerSpec.scala
@@ -1,0 +1,126 @@
+package controllers
+
+import base.SpecBase
+import forms.EstablishedUnderScotsLawFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.EstablishedUnderScotsLawPage
+import play.api.inject.bind
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.EstablishedUnderScotsLawView
+
+class EstablishedUnderScotsLawControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new EstablishedUnderScotsLawFormProvider()
+  val form = formProvider()
+
+  lazy val establishedUnderScotsLawRoute = routes.EstablishedUnderScotsLawController.onPageLoad(NormalMode).url
+
+  "EstablishedUnderScotsLaw Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, establishedUnderScotsLawRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[EstablishedUnderScotsLawView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(EstablishedUnderScotsLawPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, establishedUnderScotsLawRoute)
+
+      val view = application.injector.instanceOf[EstablishedUnderScotsLawView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, establishedUnderScotsLawRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, establishedUnderScotsLawRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[EstablishedUnderScotsLawView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, establishedUnderScotsLawRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, establishedUnderScotsLawRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/GovernedOutsideTheUKControllerSpec.scala
+++ b/test/controllers/GovernedOutsideTheUKControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/GovernedOutsideTheUKControllerSpec.scala
+++ b/test/controllers/GovernedOutsideTheUKControllerSpec.scala
@@ -53,6 +53,8 @@ class GovernedOutsideTheUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class GovernedOutsideTheUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class GovernedOutsideTheUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class GovernedOutsideTheUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class GovernedOutsideTheUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class GovernedOutsideTheUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/GovernedOutsideTheUKControllerSpec.scala
+++ b/test/controllers/GovernedOutsideTheUKControllerSpec.scala
@@ -1,0 +1,126 @@
+package controllers
+
+import base.SpecBase
+import forms.GovernedOutsideTheUKFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.GovernedOutsideTheUKPage
+import play.api.inject.bind
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.GovernedOutsideTheUKView
+
+class GovernedOutsideTheUKControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new GovernedOutsideTheUKFormProvider()
+  val form = formProvider()
+
+  lazy val governedOutsideTheUKRoute = routes.GovernedOutsideTheUKController.onPageLoad(NormalMode).url
+
+  "GovernedOutsideTheUK Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, governedOutsideTheUKRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[GovernedOutsideTheUKView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(GovernedOutsideTheUKPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, governedOutsideTheUKRoute)
+
+      val view = application.injector.instanceOf[GovernedOutsideTheUKView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, governedOutsideTheUKRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, governedOutsideTheUKRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[GovernedOutsideTheUKView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, governedOutsideTheUKRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, governedOutsideTheUKRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -39,6 +39,8 @@ class IndexControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view()(fakeRequest, messages).toString
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/InheritanceTaxActControllerSpec.scala
+++ b/test/controllers/InheritanceTaxActControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/InheritanceTaxActControllerSpec.scala
+++ b/test/controllers/InheritanceTaxActControllerSpec.scala
@@ -1,0 +1,126 @@
+package controllers
+
+import base.SpecBase
+import forms.InheritanceTaxActFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.InheritanceTaxActPage
+import play.api.inject.bind
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.InheritanceTaxActView
+
+class InheritanceTaxActControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new InheritanceTaxActFormProvider()
+  val form = formProvider()
+
+  lazy val inheritanceTaxActRoute = routes.InheritanceTaxActController.onPageLoad(NormalMode).url
+
+  "InheritanceTaxAct Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, inheritanceTaxActRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[InheritanceTaxActView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(InheritanceTaxActPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, inheritanceTaxActRoute)
+
+      val view = application.injector.instanceOf[InheritanceTaxActView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, inheritanceTaxActRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, inheritanceTaxActRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[InheritanceTaxActView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, inheritanceTaxActRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, inheritanceTaxActRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/InheritanceTaxActControllerSpec.scala
+++ b/test/controllers/InheritanceTaxActControllerSpec.scala
@@ -53,6 +53,8 @@ class InheritanceTaxActControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class InheritanceTaxActControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class InheritanceTaxActControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class InheritanceTaxActControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class InheritanceTaxActControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class InheritanceTaxActControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/NonResidentTypeControllerSpec.scala
+++ b/test/controllers/NonResidentTypeControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/NonResidentTypeControllerSpec.scala
+++ b/test/controllers/NonResidentTypeControllerSpec.scala
@@ -53,6 +53,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(NonResidentType.values.head), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -121,6 +129,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -136,6 +146,8 @@ class NonResidentTypeControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/NonResidentTypeControllerSpec.scala
+++ b/test/controllers/NonResidentTypeControllerSpec.scala
@@ -1,0 +1,125 @@
+package controllers
+
+import base.SpecBase
+import forms.NonResidentTypeFormProvider
+import models.{NormalMode, NonResidentType, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.NonResidentTypePage
+import play.api.inject.bind
+import play.api.libs.json.{JsString, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.NonResidentTypeView
+
+class NonResidentTypeControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  lazy val non-residentTypeRoute = routes.NonResidentTypeController.onPageLoad(NormalMode).url
+
+  val formProvider = new NonResidentTypeFormProvider()
+  val form = formProvider()
+
+  "Non-residentType Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, non-residentTypeRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[NonResidentTypeView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(NonResidentTypePage, NonResidentType.values.head).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, non-residentTypeRoute)
+
+      val view = application.injector.instanceOf[NonResidentTypeView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(NonResidentType.values.head), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, non-residentTypeRoute)
+          .withFormUrlEncodedBody(("value", NonResidentType.options.head.value))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, non-residentTypeRoute)
+          .withFormUrlEncodedBody(("value", "invalid value"))
+
+      val boundForm = form.bind(Map("value" -> "invalid value"))
+
+      val view = application.injector.instanceOf[NonResidentTypeView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, non-residentTypeRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, non-residentTypeRoute)
+          .withFormUrlEncodedBody(("value", NonResidentType.values.head.toString))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/RegisteringTrustFor5AControllerSpec.scala
+++ b/test/controllers/RegisteringTrustFor5AControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/RegisteringTrustFor5AControllerSpec.scala
+++ b/test/controllers/RegisteringTrustFor5AControllerSpec.scala
@@ -53,6 +53,8 @@ class RegisteringTrustFor5AControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class RegisteringTrustFor5AControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class RegisteringTrustFor5AControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class RegisteringTrustFor5AControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class RegisteringTrustFor5AControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class RegisteringTrustFor5AControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/RegisteringTrustFor5AControllerSpec.scala
+++ b/test/controllers/RegisteringTrustFor5AControllerSpec.scala
@@ -1,0 +1,126 @@
+package controllers
+
+import base.SpecBase
+import forms.RegisteringTrustFor5AFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.RegisteringTrustFor5APage
+import play.api.inject.bind
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.RegisteringTrustFor5AView
+
+class RegisteringTrustFor5AControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new RegisteringTrustFor5AFormProvider()
+  val form = formProvider()
+
+  lazy val registeringTrustFor5ARoute = routes.RegisteringTrustFor5AController.onPageLoad(NormalMode).url
+
+  "RegisteringTrustFor5A Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, registeringTrustFor5ARoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[RegisteringTrustFor5AView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(RegisteringTrustFor5APage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, registeringTrustFor5ARoute)
+
+      val view = application.injector.instanceOf[RegisteringTrustFor5AView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, registeringTrustFor5ARoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, registeringTrustFor5ARoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[RegisteringTrustFor5AView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, registeringTrustFor5ARoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, registeringTrustFor5ARoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/SessionExpiredControllerSpec.scala
+++ b/test/controllers/SessionExpiredControllerSpec.scala
@@ -39,6 +39,8 @@ class SessionExpiredControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view()(fakeRequest, messages).toString
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/TrustNameControllerSpec.scala
+++ b/test/controllers/TrustNameControllerSpec.scala
@@ -118,7 +118,7 @@ class TrustNameControllerSpec extends SpecBase {
       application.stop()
     }
 
-    "redirect to Session Expired for a GET if no existing data is found" in {
+    "return OK for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -126,28 +126,10 @@ class TrustNameControllerSpec extends SpecBase {
 
       val result = route(application, request).value
 
-      status(result) mustEqual SEE_OTHER
-
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+      status(result) mustEqual OK
 
       application.stop()
     }
 
-    "redirect to Session Expired for a POST if no existing data is found" in {
-
-      val application = applicationBuilder(userAnswers = None).build()
-
-      val request =
-        FakeRequest(POST, trustNameRoute)
-          .withFormUrlEncodedBody(("value", "answer"))
-
-      val result = route(application, request).value
-
-      status(result) mustEqual SEE_OTHER
-
-      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
-
-      application.stop()
-    }
   }
 }

--- a/test/controllers/TrustNameControllerSpec.scala
+++ b/test/controllers/TrustNameControllerSpec.scala
@@ -1,0 +1,125 @@
+package controllers
+
+import base.SpecBase
+import forms.TrustNameFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.TrustNamePage
+import play.api.inject.bind
+import play.api.libs.json.{JsString, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.TrustNameView
+
+class TrustNameControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new TrustNameFormProvider()
+  val form = formProvider()
+
+  lazy val trustNameRoute = routes.TrustNameController.onPageLoad(NormalMode).url
+
+  "TrustName Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, trustNameRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[TrustNameView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(TrustNamePage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, trustNameRoute)
+
+      val view = application.injector.instanceOf[TrustNameView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, trustNameRoute)
+          .withFormUrlEncodedBody(("value", "answer"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, trustNameRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[TrustNameView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, trustNameRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, trustNameRoute)
+          .withFormUrlEncodedBody(("value", "answer"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/TrustNameControllerSpec.scala
+++ b/test/controllers/TrustNameControllerSpec.scala
@@ -53,6 +53,8 @@ class TrustNameControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class TrustNameControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -88,6 +92,8 @@ class TrustNameControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -108,6 +114,8 @@ class TrustNameControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -121,6 +129,8 @@ class TrustNameControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -136,6 +146,8 @@ class TrustNameControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/TrustPreviouslyResidentControllerSpec.scala
+++ b/test/controllers/TrustPreviouslyResidentControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/TrustPreviouslyResidentControllerSpec.scala
+++ b/test/controllers/TrustPreviouslyResidentControllerSpec.scala
@@ -1,0 +1,125 @@
+package controllers
+
+import base.SpecBase
+import forms.TrustPreviouslyResidentFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.TrustPreviouslyResidentPage
+import play.api.inject.bind
+import play.api.libs.json.{JsString, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.TrustPreviouslyResidentView
+
+class TrustPreviouslyResidentControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new TrustPreviouslyResidentFormProvider()
+  val form = formProvider()
+
+  lazy val trustPreviouslyResidentRoute = routes.TrustPreviouslyResidentController.onPageLoad(NormalMode).url
+
+  "TrustPreviouslyResident Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, trustPreviouslyResidentRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[TrustPreviouslyResidentView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(TrustPreviouslyResidentPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, trustPreviouslyResidentRoute)
+
+      val view = application.injector.instanceOf[TrustPreviouslyResidentView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, trustPreviouslyResidentRoute)
+          .withFormUrlEncodedBody(("value", "answer"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, trustPreviouslyResidentRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[TrustPreviouslyResidentView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, trustPreviouslyResidentRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, trustPreviouslyResidentRoute)
+          .withFormUrlEncodedBody(("value", "answer"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/TrustPreviouslyResidentControllerSpec.scala
+++ b/test/controllers/TrustPreviouslyResidentControllerSpec.scala
@@ -53,6 +53,8 @@ class TrustPreviouslyResidentControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class TrustPreviouslyResidentControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -88,6 +92,8 @@ class TrustPreviouslyResidentControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -108,6 +114,8 @@ class TrustPreviouslyResidentControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -121,6 +129,8 @@ class TrustPreviouslyResidentControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -136,6 +146,8 @@ class TrustPreviouslyResidentControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/TrustResidentInUKControllerSpec.scala
+++ b/test/controllers/TrustResidentInUKControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/TrustResidentInUKControllerSpec.scala
+++ b/test/controllers/TrustResidentInUKControllerSpec.scala
@@ -1,53 +1,37 @@
-/*
- * Copyright 2018 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package controllers
 
 import base.SpecBase
-import forms.TrustNameFormProvider
+import forms.TrustResidentInUKFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import pages.TrustNamePage
+import pages.TrustResidentInUKPage
 import play.api.inject.bind
-import play.api.libs.json.{JsString, Json}
+import play.api.libs.json.{JsBoolean, Json}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import views.html.TrustNameView
+import views.html.TrustResidentInUKView
 
-class TrustNameControllerSpec extends SpecBase {
+class TrustResidentInUKControllerSpec extends SpecBase {
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new TrustNameFormProvider()
+  val formProvider = new TrustResidentInUKFormProvider()
   val form = formProvider()
 
-  lazy val trustNameRoute = routes.TrustNameController.onPageLoad(NormalMode).url
+  lazy val trustResidentInUKRoute = routes.TrustResidentInUKController.onPageLoad(NormalMode).url
 
-  "TrustName Controller" must {
+  "TrustResidentInUK Controller" must {
 
     "return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val request = FakeRequest(GET, trustNameRoute)
+      val request = FakeRequest(GET, trustResidentInUKRoute)
 
       val result = route(application, request).value
 
-      val view = application.injector.instanceOf[TrustNameView]
+      val view = application.injector.instanceOf[TrustResidentInUKView]
 
       status(result) mustEqual OK
 
@@ -57,20 +41,20 @@ class TrustNameControllerSpec extends SpecBase {
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(TrustNamePage, "answer").success.value
+      val userAnswers = UserAnswers(userAnswersId).set(TrustResidentInUKPage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, trustNameRoute)
+      val request = FakeRequest(GET, trustResidentInUKRoute)
 
-      val view = application.injector.instanceOf[TrustNameView]
+      val view = application.injector.instanceOf[TrustResidentInUKView]
 
       val result = route(application, request).value
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill("answer"), NormalMode)(fakeRequest, messages).toString
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -81,12 +65,13 @@ class TrustNameControllerSpec extends SpecBase {
           .build()
 
       val request =
-        FakeRequest(POST, trustNameRoute)
-          .withFormUrlEncodedBody(("value", "answer"))
+        FakeRequest(POST, trustResidentInUKRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
+
       redirectLocation(result).value mustEqual onwardRoute.url
     }
 
@@ -95,12 +80,12 @@ class TrustNameControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request =
-        FakeRequest(POST, trustNameRoute)
+        FakeRequest(POST, trustResidentInUKRoute)
           .withFormUrlEncodedBody(("value", ""))
 
       val boundForm = form.bind(Map("value" -> ""))
 
-      val view = application.injector.instanceOf[TrustNameView]
+      val view = application.injector.instanceOf[TrustResidentInUKView]
 
       val result = route(application, request).value
 
@@ -114,7 +99,7 @@ class TrustNameControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request = FakeRequest(GET, trustNameRoute)
+      val request = FakeRequest(GET, trustResidentInUKRoute)
 
       val result = route(application, request).value
 
@@ -128,8 +113,8 @@ class TrustNameControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       val request =
-        FakeRequest(POST, trustNameRoute)
-          .withFormUrlEncodedBody(("value", "answer"))
+        FakeRequest(POST, trustResidentInUKRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
 

--- a/test/controllers/TrustResidentInUKControllerSpec.scala
+++ b/test/controllers/TrustResidentInUKControllerSpec.scala
@@ -53,6 +53,8 @@ class TrustResidentInUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class TrustResidentInUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class TrustResidentInUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class TrustResidentInUKControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class TrustResidentInUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class TrustResidentInUKControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/TrustResidentOffshoreControllerSpec.scala
+++ b/test/controllers/TrustResidentOffshoreControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/TrustResidentOffshoreControllerSpec.scala
+++ b/test/controllers/TrustResidentOffshoreControllerSpec.scala
@@ -53,6 +53,8 @@ class TrustResidentOffshoreControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
@@ -71,6 +73,8 @@ class TrustResidentOffshoreControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -89,6 +93,8 @@ class TrustResidentOffshoreControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
     }
 
     "return a Bad Request and errors when invalid data is submitted" in {
@@ -109,6 +115,8 @@ class TrustResidentOffshoreControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
@@ -122,6 +130,8 @@ class TrustResidentOffshoreControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
@@ -137,6 +147,8 @@ class TrustResidentOffshoreControllerSpec extends SpecBase {
       status(result) mustEqual SEE_OTHER
 
       redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/TrustResidentOffshoreControllerSpec.scala
+++ b/test/controllers/TrustResidentOffshoreControllerSpec.scala
@@ -1,0 +1,126 @@
+package controllers
+
+import base.SpecBase
+import forms.TrustResidentOffshoreFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import pages.TrustResidentOffshorePage
+import play.api.inject.bind
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.TrustResidentOffshoreView
+
+class TrustResidentOffshoreControllerSpec extends SpecBase {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new TrustResidentOffshoreFormProvider()
+  val form = formProvider()
+
+  lazy val trustResidentOffshoreRoute = routes.TrustResidentOffshoreController.onPageLoad(NormalMode).url
+
+  "TrustResidentOffshore Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, trustResidentOffshoreRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[TrustResidentOffshoreView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(TrustResidentOffshorePage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, trustResidentOffshoreRoute)
+
+      val view = application.injector.instanceOf[TrustResidentOffshoreView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(true), NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+          .build()
+
+      val request =
+        FakeRequest(POST, trustResidentOffshoreRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, trustResidentOffshoreRoute)
+          .withFormUrlEncodedBody(("value", ""))
+
+      val boundForm = form.bind(Map("value" -> ""))
+
+      val view = application.injector.instanceOf[TrustResidentOffshoreView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, trustResidentOffshoreRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, trustResidentOffshoreRoute)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+    }
+  }
+}

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -39,6 +39,8 @@ class UnauthorisedControllerSpec extends SpecBase {
 
       contentAsString(result) mustEqual
         view()(fakeRequest, messages).toString
+
+      application.stop()
     }
   }
 }

--- a/test/controllers/WhenTrustSetupControllerSpec.scala
+++ b/test/controllers/WhenTrustSetupControllerSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import java.time.{LocalDate, ZoneOffset}
+
+import base.SpecBase
+import forms.WhenTrustSetupFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import pages.WhenTrustSetupPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.WhenTrustSetupView
+
+import scala.concurrent.Future
+
+class WhenTrustSetupControllerSpec extends SpecBase with MockitoSugar {
+
+  val formProvider = new WhenTrustSetupFormProvider()
+  val form = formProvider()
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val validAnswer = LocalDate.now(ZoneOffset.UTC)
+
+  lazy val whenTrustSetupRoute = routes.WhenTrustSetupController.onPageLoad(NormalMode).url
+
+  "WhenTrustSetup Controller" must {
+
+    "return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request = FakeRequest(GET, whenTrustSetupRoute)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[WhenTrustSetupView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(WhenTrustSetupPage, validAnswer).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      val request = FakeRequest(GET, whenTrustSetupRoute)
+
+      val view = application.injector.instanceOf[WhenTrustSetupView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual
+        view(form.fill(validAnswer), NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      val request =
+        FakeRequest(POST, whenTrustSetupRoute)
+          .withFormUrlEncodedBody(
+            "value.day"   -> validAnswer.getDayOfMonth.toString,
+            "value.month" -> validAnswer.getMonthValue.toString,
+            "value.year"  -> validAnswer.getYear.toString
+          )
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual onwardRoute.url
+
+      application.stop()
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, whenTrustSetupRoute)
+          .withFormUrlEncodedBody(("value", "invalid value"))
+
+      val boundForm = form.bind(Map("value" -> "invalid value"))
+
+      val view = application.injector.instanceOf[WhenTrustSetupView]
+
+      val result = route(application, request).value
+
+      status(result) mustEqual BAD_REQUEST
+
+      contentAsString(result) mustEqual
+        view(boundForm, NormalMode)(fakeRequest, messages).toString
+
+      application.stop()
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request = FakeRequest(GET, whenTrustSetupRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      val request =
+        FakeRequest(POST, whenTrustSetupRoute)
+          .withFormUrlEncodedBody(
+            "value.day"   -> validAnswer.getDayOfMonth.toString,
+            "value.month" -> validAnswer.getMonthValue.toString,
+            "value.year"  -> validAnswer.getYear.toString
+          )
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustEqual routes.SessionExpiredController.onPageLoad().url
+
+      application.stop()
+    }
+  }
+}

--- a/test/forms/AdministrationOutsideUKFormProviderSpec.scala
+++ b/test/forms/AdministrationOutsideUKFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class AdministrationOutsideUKFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "administrationOutsideUK.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new AdministrationOutsideUKFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/AdministrationOutsideUKFormProviderSpec.scala
+++ b/test/forms/AdministrationOutsideUKFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/AgentOtherThanBarristerFormProviderSpec.scala
+++ b/test/forms/AgentOtherThanBarristerFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class AgentOtherThanBarristerFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "agentOtherThanBarrister.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new AgentOtherThanBarristerFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/AgentOtherThanBarristerFormProviderSpec.scala
+++ b/test/forms/AgentOtherThanBarristerFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/CountryAdministeringTrustFormProviderSpec.scala
+++ b/test/forms/CountryAdministeringTrustFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours

--- a/test/forms/CountryAdministeringTrustFormProviderSpec.scala
+++ b/test/forms/CountryAdministeringTrustFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class CountryAdministeringTrustFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "countryAdministeringTrust.error.required"
+  val lengthKey = "countryAdministeringTrust.error.length"
+  val maxLength = 100
+
+  val form = new CountryAdministeringTrustFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/CountryGoverningTrustFormProviderSpec.scala
+++ b/test/forms/CountryGoverningTrustFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours

--- a/test/forms/CountryGoverningTrustFormProviderSpec.scala
+++ b/test/forms/CountryGoverningTrustFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class CountryGoverningTrustFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "countryGoverningTrust.error.required"
+  val lengthKey = "countryGoverningTrust.error.length"
+  val maxLength = 100
+
+  val form = new CountryGoverningTrustFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/EstablishedUnderScotsLawFormProviderSpec.scala
+++ b/test/forms/EstablishedUnderScotsLawFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class EstablishedUnderScotsLawFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "establishedUnderScotsLaw.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new EstablishedUnderScotsLawFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/EstablishedUnderScotsLawFormProviderSpec.scala
+++ b/test/forms/EstablishedUnderScotsLawFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/GovernedOutsideTheUKFormProviderSpec.scala
+++ b/test/forms/GovernedOutsideTheUKFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class GovernedOutsideTheUKFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "governedOutsideTheUK.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new GovernedOutsideTheUKFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/GovernedOutsideTheUKFormProviderSpec.scala
+++ b/test/forms/GovernedOutsideTheUKFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/InheritanceTaxActFormProviderSpec.scala
+++ b/test/forms/InheritanceTaxActFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class InheritanceTaxActFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "inheritanceTaxAct.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new InheritanceTaxActFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/InheritanceTaxActFormProviderSpec.scala
+++ b/test/forms/InheritanceTaxActFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/Non-residentTypeFormProviderSpec.scala
+++ b/test/forms/Non-residentTypeFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.OptionFieldBehaviours

--- a/test/forms/Non-residentTypeFormProviderSpec.scala
+++ b/test/forms/Non-residentTypeFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.OptionFieldBehaviours
+import models.Non-residentType
+import play.api.data.FormError
+
+class Non-residentTypeFormProviderSpec extends OptionFieldBehaviours {
+
+  val form = new Non-residentTypeFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+    val requiredKey = "non-residentType.error.required"
+
+    behave like optionsField[Non-residentType](
+      form,
+      fieldName,
+      validValues  = Non-residentType.values,
+      invalidError = FormError(fieldName, "error.invalid")
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/NonResidentTypeFormProviderSpec.scala
+++ b/test/forms/NonResidentTypeFormProviderSpec.scala
@@ -17,22 +17,22 @@
 package forms
 
 import forms.behaviours.OptionFieldBehaviours
-import models.Non-residentType
+import models.NonResidentType
 import play.api.data.FormError
 
-class Non-residentTypeFormProviderSpec extends OptionFieldBehaviours {
+class NonResidentTypeFormProviderSpec extends OptionFieldBehaviours {
 
-  val form = new Non-residentTypeFormProvider()()
+  val form = new NonResidentTypeFormProvider()()
 
   ".value" must {
 
     val fieldName = "value"
     val requiredKey = "non-residentType.error.required"
 
-    behave like optionsField[Non-residentType](
+    behave like optionsField[NonResidentType](
       form,
       fieldName,
-      validValues  = Non-residentType.values,
+      validValues  = NonResidentType.values,
       invalidError = FormError(fieldName, "error.invalid")
     )
 

--- a/test/forms/RegisteringTrustFor5AFormProviderSpec.scala
+++ b/test/forms/RegisteringTrustFor5AFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class RegisteringTrustFor5AFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "registeringTrustFor5A.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new RegisteringTrustFor5AFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/RegisteringTrustFor5AFormProviderSpec.scala
+++ b/test/forms/RegisteringTrustFor5AFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/TrustNameFormProviderSpec.scala
+++ b/test/forms/TrustNameFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours

--- a/test/forms/TrustNameFormProviderSpec.scala
+++ b/test/forms/TrustNameFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class TrustNameFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "trustName.error.required"
+  val lengthKey = "trustName.error.length"
+  val maxLength = 53
+
+  val form = new TrustNameFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/TrustPreviouslyResidentFormProviderSpec.scala
+++ b/test/forms/TrustPreviouslyResidentFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours

--- a/test/forms/TrustPreviouslyResidentFormProviderSpec.scala
+++ b/test/forms/TrustPreviouslyResidentFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class TrustPreviouslyResidentFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "trustPreviouslyResident.error.required"
+  val lengthKey = "trustPreviouslyResident.error.length"
+  val maxLength = 100
+
+  val form = new TrustPreviouslyResidentFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/TrustResidentInUKFormProviderSpec.scala
+++ b/test/forms/TrustResidentInUKFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class TrustResidentInUKFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "trustResidentInUK.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new TrustResidentInUKFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/TrustResidentInUKFormProviderSpec.scala
+++ b/test/forms/TrustResidentInUKFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/TrustResidentOffshoreFormProviderSpec.scala
+++ b/test/forms/TrustResidentOffshoreFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class TrustResidentOffshoreFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "trustResidentOffshore.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new TrustResidentOffshoreFormProvider()()
+
+  ".value" must {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/TrustResidentOffshoreFormProviderSpec.scala
+++ b/test/forms/TrustResidentOffshoreFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours

--- a/test/forms/WhenTrustSetupFormProviderSpec.scala
+++ b/test/forms/WhenTrustSetupFormProviderSpec.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +12,28 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import viewmodels.AnswerRow
+package forms
 
-@(row: AnswerRow)(implicit messages: Messages)
+import java.time.{LocalDate, ZoneOffset}
 
-<li>
-    <div class="cya-question">@messages(row.label)</div>
-    <div class="cya-answer">
-        @row.answer
-    </div>
-    <div class="cya-change">
-        <a href='@row.changeUrl'>
-            <span aria-hidden="true">@messages("site.edit")</span>
-            <span class="visually-hidden">@messages("site.hidden-edit", messages(row.label))</span>
-        </a>
-    </div>
-</li>
+import forms.behaviours.DateBehaviours
+import play.api.data.FormError
+
+class WhenTrustSetupFormProviderSpec extends DateBehaviours {
+
+  val form = new WhenTrustSetupFormProvider()()
+
+  ".value" should {
+
+    val validData = datesBetween(
+      min = LocalDate.of(2000, 1, 1),
+      max = LocalDate.now(ZoneOffset.UTC)
+    )
+
+    behave like dateField(form, "value", validData)
+
+    behave like mandatoryDateField(form, "value", "whenTrustSetup.error.required.all")
+  }
+}

--- a/test/forms/behaviours/DateBehaviours.scala
+++ b/test/forms/behaviours/DateBehaviours.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.behaviours
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import org.scalacheck.Gen
+import play.api.data.{Form, FormError}
+
+class DateBehaviours extends FieldBehaviours {
+
+  def dateField(form: Form[_], key: String, validData: Gen[LocalDate]): Unit = {
+
+    "bind valid data" in {
+
+      forAll(validData -> "valid date") {
+        date =>
+
+          val data = Map(
+            s"$key.day"   -> date.getDayOfMonth.toString,
+            s"$key.month" -> date.getMonthValue.toString,
+            s"$key.year"  -> date.getYear.toString
+          )
+
+          val result = form.bind(data)
+
+          result.value.value shouldEqual date
+      }
+    }
+  }
+
+  def dateFieldWithMax(form: Form[_], key: String, max: LocalDate, formError: FormError): Unit = {
+
+    s"fail to bind a date greater than ${max.format(DateTimeFormatter.ISO_LOCAL_DATE)}" in {
+
+      val generator = datesBetween(max.plusDays(1), max.plusYears(10))
+
+      forAll(generator -> "invalid dates") {
+        date =>
+
+          val data = Map(
+            s"$key.day"   -> date.getDayOfMonth.toString,
+            s"$key.month" -> date.getMonthValue.toString,
+            s"$key.year"  -> date.getYear.toString
+          )
+
+          val result = form.bind(data)
+
+          result.errors should contain only formError
+      }
+    }
+  }
+
+  def dateFieldWithMin(form: Form[_], key: String, min: LocalDate, formError: FormError): Unit = {
+
+    s"fail to bind a date greater than ${min.format(DateTimeFormatter.ISO_LOCAL_DATE)}" in {
+
+      val generator = datesBetween(min.minusYears(10), min.minusDays(1))
+
+      forAll(generator -> "invalid dates") {
+        date =>
+
+          val data = Map(
+            s"$key.day"   -> date.getDayOfMonth.toString,
+            s"$key.month" -> date.getMonthValue.toString,
+            s"$key.year"  -> date.getYear.toString
+          )
+
+          val result = form.bind(data)
+
+          result.errors should contain only formError
+      }
+    }
+  }
+
+  def mandatoryDateField(form: Form[_], key: String, requiredAllKey: String): Unit = {
+
+    "fail to bind an empty date" in {
+
+      val result = form.bind(Map.empty[String, String])
+
+      result.errors should contain only FormError(key, requiredAllKey, List("day", "month", "year"))
+    }
+  }
+}

--- a/test/forms/mappings/DateMappingsSpec.scala
+++ b/test/forms/mappings/DateMappingsSpec.scala
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import java.time.LocalDate
+
+import generators.Generators
+import org.scalacheck.Gen
+import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
+import org.scalatest.prop.PropertyChecks
+import play.api.data.{Form, FormError}
+
+class DateMappingsSpec extends FreeSpec with MustMatchers with PropertyChecks with Generators with OptionValues
+  with Mappings {
+
+  val form = Form(
+    "value" -> localDate(
+      requiredKey    = "error.required",
+      allRequiredKey = "error.required.all",
+      twoRequiredKey = "error.required.two",
+      invalidKey     = "error.invalid"
+    )
+  )
+
+  val validData = datesBetween(
+    min = LocalDate.of(2000, 1, 1),
+    max = LocalDate.of(3000, 1, 1)
+  )
+
+  val invalidField: Gen[String] = Gen.alphaStr.suchThat(_.nonEmpty)
+
+  val missingField: Gen[Option[String]] = Gen.option(Gen.const(""))
+
+  "bind valid data" in {
+
+    forAll(validData -> "valid date") {
+      date =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonthValue.toString,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.value.value mustEqual date
+    }
+  }
+
+  "fail to bind an empty date" in {
+
+    val result = form.bind(Map.empty[String, String])
+
+    result.errors must contain only FormError("value", "error.required.all", List("day", "month", "year"))
+  }
+
+  "fail to bind a date with a missing day" in {
+
+    forAll(validData -> "valid date", missingField -> "missing field") {
+      (date, field) =>
+
+        val initialData = Map(
+          "value.month" -> date.getMonthValue.toString,
+          "value.year" -> date.getYear.toString
+        )
+
+        val data = field.fold(initialData) {
+          value =>
+            initialData + ("value.day" -> value)
+        }
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.required", List("day"))
+    }
+  }
+
+  "fail to bind a date with an invalid day" in {
+
+    forAll(validData -> "valid date", invalidField -> "invalid field") {
+      (date, field) =>
+
+        val data = Map(
+          "value.day" -> field,
+          "value.month" -> date.getMonthValue.toString,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain(
+          FormError("value", "error.invalid", List("day", "month", "year"))
+        )
+    }
+  }
+
+  "fail to bind a date with a missing month" in {
+
+    forAll(validData -> "valid date", missingField -> "missing field") {
+      (date, field) =>
+
+        val initialData = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.year" -> date.getYear.toString
+        )
+
+        val data = field.fold(initialData) {
+          value =>
+            initialData + ("value.month" -> value)
+        }
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.required", List("month"))
+    }
+  }
+
+  "fail to bind a date with an invalid month" in {
+
+    forAll(validData -> "valid data", invalidField -> "invalid field") {
+      (date, field) =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> field,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain(
+          FormError("value", "error.invalid", List("day", "month", "year"))
+        )
+    }
+  }
+
+  "fail to bind a date with a missing year" in {
+
+    forAll(validData -> "valid date", missingField -> "missing field") {
+      (date, field) =>
+
+        val initialData = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonthValue.toString
+        )
+
+        val data = field.fold(initialData) {
+          value =>
+            initialData + ("value.year" -> value)
+        }
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.required", List("year"))
+    }
+  }
+
+  "fail to bind a date with an invalid year" in {
+
+    forAll(validData -> "valid data", invalidField -> "invalid field") {
+      (date, field) =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonthValue.toString,
+          "value.year" -> field
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain(
+          FormError("value", "error.invalid", List("day", "month", "year"))
+        )
+    }
+  }
+
+  "fail to bind a date with a missing day and month" in {
+
+    forAll(validData -> "valid date", missingField -> "missing day", missingField -> "missing month") {
+      (date, dayOpt, monthOpt) =>
+
+        val day = dayOpt.fold(Map.empty[String, String]) {
+          value =>
+            Map("value.day" -> value)
+        }
+
+        val month = monthOpt.fold(Map.empty[String, String]) {
+          value =>
+            Map("value.month" -> value)
+        }
+
+        val data: Map[String, String] = Map(
+          "value.year" -> date.getYear.toString
+        ) ++ day ++ month
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.required.two", List("day", "month"))
+    }
+  }
+
+  "fail to bind a date with a missing day and year" in {
+
+    forAll(validData -> "valid date", missingField -> "missing day", missingField -> "missing year") {
+      (date, dayOpt, yearOpt) =>
+
+        val day = dayOpt.fold(Map.empty[String, String]) {
+          value =>
+            Map("value.day" -> value)
+        }
+
+        val year = yearOpt.fold(Map.empty[String, String]) {
+          value =>
+            Map("value.year" -> value)
+        }
+
+        val data: Map[String, String] = Map(
+          "value.month" -> date.getMonthValue.toString
+        ) ++ day ++ year
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.required.two", List("day", "year"))
+    }
+  }
+
+  "fail to bind a date with a missing month and year" in {
+
+    forAll(validData -> "valid date", missingField -> "missing month", missingField -> "missing year") {
+      (date, monthOpt, yearOpt) =>
+
+        val month = monthOpt.fold(Map.empty[String, String]) {
+          value =>
+            Map("value.month" -> value)
+        }
+
+        val year = yearOpt.fold(Map.empty[String, String]) {
+          value =>
+            Map("value.year" -> value)
+        }
+
+        val data: Map[String, String] = Map(
+          "value.day" -> date.getDayOfMonth.toString
+        ) ++ month ++ year
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.required.two", List("month", "year"))
+    }
+  }
+
+  "fail to bind an invalid day and month" in {
+
+    forAll(validData -> "valid date", invalidField -> "invalid day", invalidField -> "invalid month") {
+      (date, day, month) =>
+
+        val data = Map(
+          "value.day" -> day,
+          "value.month" -> month,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.invalid", List("day", "month", "year"))
+    }
+  }
+
+  "fail to bind an invalid day and year" in {
+
+    forAll(validData -> "valid date", invalidField -> "invalid day", invalidField -> "invalid year") {
+      (date, day, year) =>
+
+        val data = Map(
+          "value.day" -> day,
+          "value.month" -> date.getMonthValue.toString,
+          "value.year" -> year
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.invalid", List("day", "month", "year"))
+    }
+  }
+
+  "fail to bind an invalid month and year" in {
+
+    forAll(validData -> "valid date", invalidField -> "invalid month", invalidField -> "invalid year") {
+      (date, month, year) =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> month,
+          "value.year" -> year
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.invalid", List("day", "month", "year"))
+    }
+  }
+
+  "fail to bind an invalid day, month and year" in {
+
+    forAll(invalidField -> "valid day", invalidField -> "invalid month", invalidField -> "invalid year") {
+      (day, month, year) =>
+
+        val data = Map(
+          "value.day" -> day,
+          "value.month" -> month,
+          "value.year" -> year
+        )
+
+        val result = form.bind(data)
+
+        result.errors must contain only FormError("value", "error.invalid", List("day", "month", "year"))
+    }
+  }
+
+  "fail to bind an invalid date" in {
+
+    val data = Map(
+      "value.day" -> "30",
+      "value.month" -> "2",
+      "value.year" -> "2018"
+    )
+
+    val result = form.bind(data)
+
+    result.errors must contain(
+      FormError("value", "error.invalid", List("day", "month", "year"))
+    )
+  }
+
+  "unbind a date" in {
+
+    forAll(validData -> "valid date") {
+      date =>
+
+        val filledForm = form.fill(date)
+
+        filledForm("value.day").value.value mustEqual date.getDayOfMonth.toString
+        filledForm("value.month").value.value mustEqual date.getMonthValue.toString
+        filledForm("value.year").value.value mustEqual date.getYear.toString
+    }
+  }
+}

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -21,4 +21,9 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 
 trait ModelGenerators {
+
+  implicit lazy val arbitraryNon-residentType: Arbitrary[Non-residentType] =
+    Arbitrary {
+      Gen.oneOf(Non-residentType.values.toSeq)
+    }
 }

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,9 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryTrustResidentOffshorePage: Arbitrary[TrustResidentOffshorePage.type] =
+    Arbitrary(TrustResidentOffshorePage)
+
   implicit lazy val arbitraryRegisteringTrustFor5APage: Arbitrary[RegisteringTrustFor5APage.type] =
     Arbitrary(RegisteringTrustFor5APage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,9 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryCountryGoverningTrustPage: Arbitrary[CountryGoverningTrustPage.type] =
+    Arbitrary(CountryGoverningTrustPage)
+
   implicit lazy val arbitraryGovernedOutsideTheUKPage: Arbitrary[GovernedOutsideTheUKPage.type] =
     Arbitrary(GovernedOutsideTheUKPage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,9 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryTrustPreviouslyResidentPage: Arbitrary[TrustPreviouslyResidentPage.type] =
+    Arbitrary(TrustPreviouslyResidentPage)
+
   implicit lazy val arbitraryTrustResidentOffshorePage: Arbitrary[TrustResidentOffshorePage.type] =
     Arbitrary(TrustResidentOffshorePage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,9 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryWhenTrustSetupPage: Arbitrary[WhenTrustSetupPage.type] =
+    Arbitrary(WhenTrustSetupPage)
+
   implicit lazy val arbitraryAgentOtherThanBarristerPage: Arbitrary[AgentOtherThanBarristerPage.type] =
     Arbitrary(AgentOtherThanBarristerPage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,12 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryRegisteringTrustFor5APage: Arbitrary[RegisteringTrustFor5APage.type] =
+    Arbitrary(RegisteringTrustFor5APage)
+
+  implicit lazy val arbitraryEstablishedUnderScotsLawPage: Arbitrary[EstablishedUnderScotsLawPage.type] =
+    Arbitrary(EstablishedUnderScotsLawPage)
+
   implicit lazy val arbitraryTrustResidentInUKPage: Arbitrary[TrustResidentInUKPage.type] =
     Arbitrary(TrustResidentInUKPage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,9 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryAdministrationOutsideUKPage: Arbitrary[AdministrationOutsideUKPage.type] =
+    Arbitrary(AdministrationOutsideUKPage)
+
   implicit lazy val arbitraryCountryGoverningTrustPage: Arbitrary[CountryGoverningTrustPage.type] =
     Arbitrary(CountryGoverningTrustPage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -20,4 +20,7 @@ import org.scalacheck.Arbitrary
 import pages._
 
 trait PageGenerators {
+
+  implicit lazy val arbitraryTrustNamePage: Arbitrary[TrustNamePage.type] =
+    Arbitrary(TrustNamePage)
 }

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,12 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryInheritanceTaxActPage: Arbitrary[InheritanceTaxActPage.type] =
+    Arbitrary(InheritanceTaxActPage)
+
+  implicit lazy val arbitraryNon-residentTypePage: Arbitrary[Non-residentTypePage.type] =
+    Arbitrary(Non-residentTypePage)
+
   implicit lazy val arbitraryTrustPreviouslyResidentPage: Arbitrary[TrustPreviouslyResidentPage.type] =
     Arbitrary(TrustPreviouslyResidentPage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,6 +21,12 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryTrustResidentInUKPage: Arbitrary[TrustResidentInUKPage.type] =
+    Arbitrary(TrustResidentInUKPage)
+
+  implicit lazy val arbitraryCountryAdministeringTrustPage: Arbitrary[CountryAdministeringTrustPage.type] =
+    Arbitrary(CountryAdministeringTrustPage)
+
   implicit lazy val arbitraryAdministrationOutsideUKPage: Arbitrary[AdministrationOutsideUKPage.type] =
     Arbitrary(AdministrationOutsideUKPage)
 

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -21,11 +21,14 @@ import pages._
 
 trait PageGenerators {
 
+  implicit lazy val arbitraryAgentOtherThanBarristerPage: Arbitrary[AgentOtherThanBarristerPage.type] =
+    Arbitrary(AgentOtherThanBarristerPage)
+
   implicit lazy val arbitraryInheritanceTaxActPage: Arbitrary[InheritanceTaxActPage.type] =
     Arbitrary(InheritanceTaxActPage)
 
-  implicit lazy val arbitraryNon-residentTypePage: Arbitrary[Non-residentTypePage.type] =
-    Arbitrary(Non-residentTypePage)
+  implicit lazy val arbitraryNonResidentTypePage: Arbitrary[NonResidentTypePage.type] =
+    Arbitrary(NonResidentTypePage)
 
   implicit lazy val arbitraryTrustPreviouslyResidentPage: Arbitrary[TrustPreviouslyResidentPage.type] =
     Arbitrary(TrustPreviouslyResidentPage)

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryAdministrationOutsideUKUserAnswersEntry: Arbitrary[(AdministrationOutsideUKPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[AdministrationOutsideUKPage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryCountryGoverningTrustUserAnswersEntry: Arbitrary[(CountryGoverningTrustPage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryAgentOtherThanBarristerUserAnswersEntry: Arbitrary[(AgentOtherThanBarristerPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[AgentOtherThanBarristerPage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryInheritanceTaxActUserAnswersEntry: Arbitrary[(InheritanceTaxActPage.type, JsValue)] =
     Arbitrary {
       for {
@@ -32,11 +40,11 @@ trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
       } yield (page, value)
     }
 
-  implicit lazy val arbitraryNon-residentTypeUserAnswersEntry: Arbitrary[(Non-residentTypePage.type, JsValue)] =
+  implicit lazy val arbitraryNonResidentTypeUserAnswersEntry: Arbitrary[(NonResidentTypePage.type, JsValue)] =
     Arbitrary {
       for {
-        page  <- arbitrary[Non-residentTypePage.type]
-        value <- arbitrary[Non-residentType].map(Json.toJson(_))
+        page  <- arbitrary[NonResidentTypePage.type]
+        value <- arbitrary[NonResidentType].map(Json.toJson(_))
       } yield (page, value)
     }
 

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryTrustPreviouslyResidentUserAnswersEntry: Arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[TrustPreviouslyResidentPage.type]
+        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryTrustResidentOffshoreUserAnswersEntry: Arbitrary[(TrustResidentOffshorePage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,22 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryInheritanceTaxActUserAnswersEntry: Arbitrary[(InheritanceTaxActPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[InheritanceTaxActPage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
+  implicit lazy val arbitraryNon-residentTypeUserAnswersEntry: Arbitrary[(Non-residentTypePage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[Non-residentTypePage.type]
+        value <- arbitrary[Non-residentType].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryTrustPreviouslyResidentUserAnswersEntry: Arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryCountryGoverningTrustUserAnswersEntry: Arbitrary[(CountryGoverningTrustPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[CountryGoverningTrustPage.type]
+        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryGovernedOutsideTheUKUserAnswersEntry: Arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -23,4 +23,12 @@ import pages._
 import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
+
+  implicit lazy val arbitraryTrustNameUserAnswersEntry: Arbitrary[(TrustNamePage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[TrustNamePage.type]
+        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+      } yield (page, value)
+    }
 }

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryGovernedOutsideTheUKUserAnswersEntry: Arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[GovernedOutsideTheUKPage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryTrustNameUserAnswersEntry: Arbitrary[(TrustNamePage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryTrustResidentOffshoreUserAnswersEntry: Arbitrary[(TrustResidentOffshorePage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[TrustResidentOffshorePage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryRegisteringTrustFor5AUserAnswersEntry: Arbitrary[(RegisteringTrustFor5APage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,22 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryTrustResidentInUKUserAnswersEntry: Arbitrary[(TrustResidentInUKPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[TrustResidentInUKPage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
+  implicit lazy val arbitraryCountryAdministeringTrustUserAnswersEntry: Arbitrary[(CountryAdministeringTrustPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[CountryAdministeringTrustPage.type]
+        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryAdministrationOutsideUKUserAnswersEntry: Arbitrary[(AdministrationOutsideUKPage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,22 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryRegisteringTrustFor5AUserAnswersEntry: Arbitrary[(RegisteringTrustFor5APage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[RegisteringTrustFor5APage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
+  implicit lazy val arbitraryEstablishedUnderScotsLawUserAnswersEntry: Arbitrary[(EstablishedUnderScotsLawPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[EstablishedUnderScotsLawPage.type]
+        value <- arbitrary[Boolean].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryTrustResidentInUKUserAnswersEntry: Arbitrary[(TrustResidentInUKPage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,6 +24,14 @@ import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
 
+  implicit lazy val arbitraryWhenTrustSetupUserAnswersEntry: Arbitrary[(WhenTrustSetupPage.type, JsValue)] =
+    Arbitrary {
+      for {
+        page  <- arbitrary[WhenTrustSetupPage.type]
+        value <- arbitrary[Int].map(Json.toJson(_))
+      } yield (page, value)
+    }
+
   implicit lazy val arbitraryAgentOtherThanBarristerUserAnswersEntry: Arbitrary[(AgentOtherThanBarristerPage.type, JsValue)] =
     Arbitrary {
       for {

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(TrustNamePage.type, JsValue)] ::
     Nil
 
   implicit lazy val arbitraryUserData: Arbitrary[UserAnswers] = {

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] ::
     arbitrary[(TrustResidentOffshorePage.type, JsValue)] ::
     arbitrary[(RegisteringTrustFor5APage.type, JsValue)] ::
     arbitrary[(EstablishedUnderScotsLawPage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,8 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(InheritanceTaxActPage.type, JsValue)] ::
+    arbitrary[(Non-residentTypePage.type, JsValue)] ::
     arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] ::
     arbitrary[(TrustResidentOffshorePage.type, JsValue)] ::
     arbitrary[(RegisteringTrustFor5APage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,8 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(RegisteringTrustFor5APage.type, JsValue)] ::
+    arbitrary[(EstablishedUnderScotsLawPage.type, JsValue)] ::
     arbitrary[(TrustResidentInUKPage.type, JsValue)] ::
     arbitrary[(CountryAdministeringTrustPage.type, JsValue)] ::
     arbitrary[(AdministrationOutsideUKPage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] ::
     arbitrary[(TrustNamePage.type, JsValue)] ::
     Nil
 

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(CountryGoverningTrustPage.type, JsValue)] ::
     arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] ::
     arbitrary[(TrustNamePage.type, JsValue)] ::
     Nil

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,8 +27,9 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(AgentOtherThanBarristerPage.type, JsValue)] ::
     arbitrary[(InheritanceTaxActPage.type, JsValue)] ::
-    arbitrary[(Non-residentTypePage.type, JsValue)] ::
+    arbitrary[(NonResidentTypePage.type, JsValue)] ::
     arbitrary[(TrustPreviouslyResidentPage.type, JsValue)] ::
     arbitrary[(TrustResidentOffshorePage.type, JsValue)] ::
     arbitrary[(RegisteringTrustFor5APage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,8 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(TrustResidentInUKPage.type, JsValue)] ::
+    arbitrary[(CountryAdministeringTrustPage.type, JsValue)] ::
     arbitrary[(AdministrationOutsideUKPage.type, JsValue)] ::
     arbitrary[(CountryGoverningTrustPage.type, JsValue)] ::
     arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(WhenTrustSetupPage.type, JsValue)] ::
     arbitrary[(AgentOtherThanBarristerPage.type, JsValue)] ::
     arbitrary[(InheritanceTaxActPage.type, JsValue)] ::
     arbitrary[(NonResidentTypePage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(AdministrationOutsideUKPage.type, JsValue)] ::
     arbitrary[(CountryGoverningTrustPage.type, JsValue)] ::
     arbitrary[(GovernedOutsideTheUKPage.type, JsValue)] ::
     arbitrary[(TrustNamePage.type, JsValue)] ::

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -27,6 +27,7 @@ trait UserAnswersGenerator extends TryValues {
   self: Generators =>
 
   val generators: Seq[Gen[(QuestionPage[_], JsValue)]] =
+    arbitrary[(TrustResidentOffshorePage.type, JsValue)] ::
     arbitrary[(RegisteringTrustFor5APage.type, JsValue)] ::
     arbitrary[(EstablishedUnderScotsLawPage.type, JsValue)] ::
     arbitrary[(TrustResidentInUKPage.type, JsValue)] ::

--- a/test/models/Non-residentTypeSpec.scala
+++ b/test/models/Non-residentTypeSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import org.scalacheck.Arbitrary.arbitrary

--- a/test/models/Non-residentTypeSpec.scala
+++ b/test/models/Non-residentTypeSpec.scala
@@ -1,0 +1,46 @@
+package models
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import play.api.libs.json.{JsError, JsString, Json}
+
+class Non-residentTypeSpec extends WordSpec with MustMatchers with PropertyChecks with OptionValues {
+
+  "Non-residentType" must {
+
+    "deserialise valid values" in {
+
+      val gen = Gen.oneOf(Non-residentType.values.toSeq)
+
+      forAll(gen) {
+        non-residentType =>
+
+          JsString(non-residentType.toString).validate[Non-residentType].asOpt.value mustEqual non-residentType
+      }
+    }
+
+    "fail to deserialise invalid values" in {
+
+      val gen = arbitrary[String] suchThat (!Non-residentType.values.map(_.toString).contains(_))
+
+      forAll(gen) {
+        invalidValue =>
+
+          JsString(invalidValue).validate[Non-residentType] mustEqual JsError("error.invalid")
+      }
+    }
+
+    "serialise" in {
+
+      val gen = Gen.oneOf(Non-residentType.values.toSeq)
+
+      forAll(gen) {
+        non-residentType =>
+
+          Json.toJson(non-residentType) mustEqual JsString(non-residentType.toString)
+      }
+    }
+  }
+}

--- a/test/models/NonResidentTypeSpec.scala
+++ b/test/models/NonResidentTypeSpec.scala
@@ -22,40 +22,40 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{MustMatchers, OptionValues, WordSpec}
 import play.api.libs.json.{JsError, JsString, Json}
 
-class Non-residentTypeSpec extends WordSpec with MustMatchers with PropertyChecks with OptionValues {
+class NonResidentTypeSpec extends WordSpec with MustMatchers with PropertyChecks with OptionValues {
 
   "Non-residentType" must {
 
     "deserialise valid values" in {
 
-      val gen = Gen.oneOf(Non-residentType.values.toSeq)
+      val gen = Gen.oneOf(NonResidentType.values.toSeq)
 
       forAll(gen) {
-        non-residentType =>
+        nonresidentType =>
 
-          JsString(non-residentType.toString).validate[Non-residentType].asOpt.value mustEqual non-residentType
+          JsString(nonresidentType.toString).validate[NonResidentType].asOpt.value mustEqual nonresidentType
       }
     }
 
     "fail to deserialise invalid values" in {
 
-      val gen = arbitrary[String] suchThat (!Non-residentType.values.map(_.toString).contains(_))
+      val gen = arbitrary[String] suchThat (!NonResidentType.values.map(_.toString).contains(_))
 
       forAll(gen) {
         invalidValue =>
 
-          JsString(invalidValue).validate[Non-residentType] mustEqual JsError("error.invalid")
+          JsString(invalidValue).validate[NonResidentType] mustEqual JsError("error.invalid")
       }
     }
 
     "serialise" in {
 
-      val gen = Gen.oneOf(Non-residentType.values.toSeq)
+      val gen = Gen.oneOf(NonResidentType.values.toSeq)
 
       forAll(gen) {
-        non-residentType =>
+        nonresidentType =>
 
-          Json.toJson(non-residentType) mustEqual JsString(non-residentType.toString)
+          Json.toJson(nonresidentType) mustEqual JsString(nonresidentType.toString)
       }
     }
   }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -119,6 +119,129 @@ class NavigatorSpec extends SpecBase with PropertyChecks with Generators{
         }
       }
 
+      "go to Registering for Purpose of 5A Schedule from Trust Resident in UK when user answers No" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(TrustResidentInUKPage, value = false).success.value
+
+            navigator.nextPage(TrustResidentInUKPage, NormalMode)(answers)
+              .mustBe(routes.RegisteringTrustFor5AController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Inheritance Tax from Registering for Purpose of Schedule 5A when user answers No" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(RegisteringTrustFor5APage, value = false).success.value
+
+            navigator.nextPage(RegisteringTrustFor5APage, NormalMode)(answers)
+              .mustBe(routes.InheritanceTaxActController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Check Your Answers from Inheritance Tax when user answers No" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(InheritanceTaxActPage, value = false).success.value
+
+            navigator.nextPage(InheritanceTaxActPage, NormalMode)(answers)
+              .mustBe(routes.CheckYourAnswersController.onPageLoad())
+        }
+      }
+
+      "go to Agent Other Than Barrister from Inheritance Tax when user answers Yes" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(InheritanceTaxActPage, value = true).success.value
+
+            navigator.nextPage(InheritanceTaxActPage, NormalMode)(answers)
+              .mustBe(routes.AgentOtherThanBarristerController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Check Your Answers from Agent Other Than Barrister" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(AgentOtherThanBarristerPage, NormalMode)(userAnswers)
+              .mustBe(routes.CheckYourAnswersController.onPageLoad())
+        }
+      }
+
+      "go to Check Your Answers from What is The Non Resident Type" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(NonResidentTypePage, NormalMode)(userAnswers)
+              .mustBe(routes.CheckYourAnswersController.onPageLoad())
+        }
+      }
+
+      "go to What Is Non Resident Type from Registering for Purpose of Schedule 5A when user answers Yes" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(RegisteringTrustFor5APage, value = true).success.value
+
+            navigator.nextPage(RegisteringTrustFor5APage, NormalMode)(answers)
+              .mustBe(routes.NonResidentTypeController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Trust Established Under Scots Law from Trust Resident in UK when user answers Yes" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(TrustResidentInUKPage, value = true).success.value
+
+            navigator.nextPage(TrustResidentInUKPage, NormalMode)(answers)
+              .mustBe(routes.EstablishedUnderScotsLawController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Was Trust Resident Previously Offshore from Trust Established Under Scots Law" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(EstablishedUnderScotsLawPage, NormalMode)(userAnswers)
+              .mustBe(routes.TrustResidentOffshoreController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Where Was The Trust Previously Resident from Was Trust Resident Offshore when user answers Yes" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(TrustResidentOffshorePage, value = true).success.value
+
+            navigator.nextPage(TrustResidentOffshorePage, NormalMode)(answers)
+              .mustBe(routes.TrustPreviouslyResidentController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Check Your Answers from Was Trust Resident Offshore when user answers No" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(TrustResidentOffshorePage, value = false).success.value
+
+            navigator.nextPage(TrustResidentOffshorePage, NormalMode)(answers)
+              .mustBe(routes.CheckYourAnswersController.onPageLoad)
+        }
+      }
+
+      "go to Check Your Answers from Where Was The Trust Previously Resident" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(TrustPreviouslyResidentPage, NormalMode)(userAnswers)
+              .mustBe(routes.CheckYourAnswersController.onPageLoad)
+        }
+      }
     }
 
     "in Check mode" must {

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -18,10 +18,13 @@ package navigation
 
 import base.SpecBase
 import controllers.routes
+import generators.Generators
+import models.{CheckMode, NormalMode, UserAnswers}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.prop.PropertyChecks
 import pages._
-import models._
 
-class NavigatorSpec extends SpecBase {
+class NavigatorSpec extends SpecBase with PropertyChecks with Generators{
 
   val navigator = new Navigator
 
@@ -34,6 +37,88 @@ class NavigatorSpec extends SpecBase {
         case object UnknownPage extends Page
         navigator.nextPage(UnknownPage, NormalMode)(UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
       }
+
+      "go to When Trust Setup from Index page" in {
+
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(TrustNamePage, NormalMode)(userAnswers)
+              .mustBe(routes.WhenTrustSetupController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Is Trust Governed By Laws Outside The UK from Trust Setup Page" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(WhenTrustSetupPage, NormalMode)(userAnswers)
+              .mustBe(routes.GovernedOutsideTheUKController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to What is the country governing the Trust from Is Trust Governed By Laws Outside The UK when the user answers Yes" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(GovernedOutsideTheUKPage, value = true).success.value
+
+            navigator.nextPage(GovernedOutsideTheUKPage, NormalMode)(answers)
+              .mustBe(routes.CountryGoverningTrustController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Is Trust Administration Done Outside UK from Is Trust Governed By Laws Outside The UK when the user answers No" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(GovernedOutsideTheUKPage, value = false).success.value
+
+            navigator.nextPage(GovernedOutsideTheUKPage, NormalMode)(answers)
+              .mustBe(routes.AdministrationOutsideUKController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Is Trust Administration Done Outside UK from What is Country Governing The Trust" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(CountryGoverningTrustPage, NormalMode)(userAnswers)
+              .mustBe(routes.AdministrationOutsideUKController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Is Trust Resident from Is Trust Administration Done Outside UK when user answers No" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(AdministrationOutsideUKPage, value = false).success.value
+
+            navigator.nextPage(AdministrationOutsideUKPage, NormalMode)(answers)
+              .mustBe(routes.TrustResidentInUKController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to What Is Country Administering from Is Trust Administration Done Outside UK when user answers Yes" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            val answers = userAnswers.set(AdministrationOutsideUKPage, value = true).success.value
+
+            navigator.nextPage(AdministrationOutsideUKPage, NormalMode)(answers)
+              .mustBe(routes.CountryAdministeringTrustController.onPageLoad(NormalMode))
+        }
+      }
+
+      "go to Is Trust Resident from What Is Country Administering" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+
+            navigator.nextPage(CountryAdministeringTrustPage, NormalMode)(userAnswers)
+              .mustBe(routes.TrustResidentInUKController.onPageLoad(NormalMode))
+        }
+      }
+
     }
 
     "in Check mode" must {
@@ -43,6 +128,7 @@ class NavigatorSpec extends SpecBase {
         case object UnknownPage extends Page
         navigator.nextPage(UnknownPage, CheckMode)(UserAnswers("id")) mustBe routes.CheckYourAnswersController.onPageLoad()
       }
+
     }
   }
 }

--- a/test/pages/AdministrationOutsideUKPageSpec.scala
+++ b/test/pages/AdministrationOutsideUKPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/AdministrationOutsideUKPageSpec.scala
+++ b/test/pages/AdministrationOutsideUKPageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class AdministrationOutsideUKPageSpec extends PageBehaviours {
+
+  "AdministrationOutsideUKPage" must {
+
+    beRetrievable[Boolean](AdministrationOutsideUKPage)
+
+    beSettable[Boolean](AdministrationOutsideUKPage)
+
+    beRemovable[Boolean](AdministrationOutsideUKPage)
+  }
+}

--- a/test/pages/AgentOtherThanBarristerPageSpec.scala
+++ b/test/pages/AgentOtherThanBarristerPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/AgentOtherThanBarristerPageSpec.scala
+++ b/test/pages/AgentOtherThanBarristerPageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class AgentOtherThanBarristerPageSpec extends PageBehaviours {
+
+  "AgentOtherThanBarristerPage" must {
+
+    beRetrievable[Boolean](AgentOtherThanBarristerPage)
+
+    beSettable[Boolean](AgentOtherThanBarristerPage)
+
+    beRemovable[Boolean](AgentOtherThanBarristerPage)
+  }
+}

--- a/test/pages/CountryAdministeringTrustPageSpec.scala
+++ b/test/pages/CountryAdministeringTrustPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/CountryAdministeringTrustPageSpec.scala
+++ b/test/pages/CountryAdministeringTrustPageSpec.scala
@@ -1,0 +1,16 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+
+class CountryAdministeringTrustPageSpec extends PageBehaviours {
+
+  "CountryAdministeringTrustPage" must {
+
+    beRetrievable[String](CountryAdministeringTrustPage)
+
+    beSettable[String](CountryAdministeringTrustPage)
+
+    beRemovable[String](CountryAdministeringTrustPage)
+  }
+}

--- a/test/pages/CountryGoverningTrustPageSpec.scala
+++ b/test/pages/CountryGoverningTrustPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/CountryGoverningTrustPageSpec.scala
+++ b/test/pages/CountryGoverningTrustPageSpec.scala
@@ -1,0 +1,16 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+
+class CountryGoverningTrustPageSpec extends PageBehaviours {
+
+  "CountryGoverningTrustPage" must {
+
+    beRetrievable[String](CountryGoverningTrustPage)
+
+    beSettable[String](CountryGoverningTrustPage)
+
+    beRemovable[String](CountryGoverningTrustPage)
+  }
+}

--- a/test/pages/EstablishedUnderScotsLawPageSpec.scala
+++ b/test/pages/EstablishedUnderScotsLawPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/EstablishedUnderScotsLawPageSpec.scala
+++ b/test/pages/EstablishedUnderScotsLawPageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class EstablishedUnderScotsLawPageSpec extends PageBehaviours {
+
+  "EstablishedUnderScotsLawPage" must {
+
+    beRetrievable[Boolean](EstablishedUnderScotsLawPage)
+
+    beSettable[Boolean](EstablishedUnderScotsLawPage)
+
+    beRemovable[Boolean](EstablishedUnderScotsLawPage)
+  }
+}

--- a/test/pages/GovernedOutsideTheUKPageSpec.scala
+++ b/test/pages/GovernedOutsideTheUKPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/GovernedOutsideTheUKPageSpec.scala
+++ b/test/pages/GovernedOutsideTheUKPageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class GovernedOutsideTheUKPageSpec extends PageBehaviours {
+
+  "GovernedOutsideTheUKPage" must {
+
+    beRetrievable[Boolean](GovernedOutsideTheUKPage)
+
+    beSettable[Boolean](GovernedOutsideTheUKPage)
+
+    beRemovable[Boolean](GovernedOutsideTheUKPage)
+  }
+}

--- a/test/pages/InheritanceTaxActPageSpec.scala
+++ b/test/pages/InheritanceTaxActPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/InheritanceTaxActPageSpec.scala
+++ b/test/pages/InheritanceTaxActPageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class InheritanceTaxActPageSpec extends PageBehaviours {
+
+  "InheritanceTaxActPage" must {
+
+    beRetrievable[Boolean](InheritanceTaxActPage)
+
+    beSettable[Boolean](InheritanceTaxActPage)
+
+    beRemovable[Boolean](InheritanceTaxActPage)
+  }
+}

--- a/test/pages/Non-residentTypePageSpec.scala
+++ b/test/pages/Non-residentTypePageSpec.scala
@@ -1,0 +1,16 @@
+package pages
+
+import models.Non-residentType
+import pages.behaviours.PageBehaviours
+
+class Non-residentTypeSpec extends PageBehaviours {
+
+  "Non-residentTypePage" must {
+
+    beRetrievable[Non-residentType](Non-residentTypePage)
+
+    beSettable[Non-residentType](Non-residentTypePage)
+
+    beRemovable[Non-residentType](Non-residentTypePage)
+  }
+}

--- a/test/pages/Non-residentTypePageSpec.scala
+++ b/test/pages/Non-residentTypePageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import models.Non-residentType

--- a/test/pages/NonResidentTypePageSpec.scala
+++ b/test/pages/NonResidentTypePageSpec.scala
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package generators
+package pages
 
-import models._
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.{Arbitrary, Gen}
+import models.NonResidentType
+import pages.behaviours.PageBehaviours
 
-trait ModelGenerators {
+class NonResidentTypePageSpec extends PageBehaviours {
 
-  implicit lazy val arbitraryNonResidentType: Arbitrary[NonResidentType] =
-    Arbitrary {
-      Gen.oneOf(NonResidentType.values.toSeq)
-    }
+  "Non-residentTypePage" must {
+
+    beRetrievable[NonResidentType](NonResidentTypePage)
+
+    beSettable[NonResidentType](NonResidentTypePage)
+
+    beRemovable[NonResidentType](NonResidentTypePage)
+  }
 }

--- a/test/pages/RegisteringTrustFor5APageSpec.scala
+++ b/test/pages/RegisteringTrustFor5APageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/RegisteringTrustFor5APageSpec.scala
+++ b/test/pages/RegisteringTrustFor5APageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class RegisteringTrustFor5APageSpec extends PageBehaviours {
+
+  "RegisteringTrustFor5APage" must {
+
+    beRetrievable[Boolean](RegisteringTrustFor5APage)
+
+    beSettable[Boolean](RegisteringTrustFor5APage)
+
+    beRemovable[Boolean](RegisteringTrustFor5APage)
+  }
+}

--- a/test/pages/TrustNamePageSpec.scala
+++ b/test/pages/TrustNamePageSpec.scala
@@ -1,0 +1,16 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+
+class TrustNamePageSpec extends PageBehaviours {
+
+  "TrustNamePage" must {
+
+    beRetrievable[String](TrustNamePage)
+
+    beSettable[String](TrustNamePage)
+
+    beRemovable[String](TrustNamePage)
+  }
+}

--- a/test/pages/TrustPreviouslyResidentPageSpec.scala
+++ b/test/pages/TrustPreviouslyResidentPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/TrustPreviouslyResidentPageSpec.scala
+++ b/test/pages/TrustPreviouslyResidentPageSpec.scala
@@ -1,0 +1,16 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+
+class TrustPreviouslyResidentPageSpec extends PageBehaviours {
+
+  "TrustPreviouslyResidentPage" must {
+
+    beRetrievable[String](TrustPreviouslyResidentPage)
+
+    beSettable[String](TrustPreviouslyResidentPage)
+
+    beRemovable[String](TrustPreviouslyResidentPage)
+  }
+}

--- a/test/pages/TrustResidentInUKPageSpec.scala
+++ b/test/pages/TrustResidentInUKPageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/TrustResidentInUKPageSpec.scala
+++ b/test/pages/TrustResidentInUKPageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class TrustResidentInUKPageSpec extends PageBehaviours {
+
+  "TrustResidentInUKPage" must {
+
+    beRetrievable[Boolean](TrustResidentInUKPage)
+
+    beSettable[Boolean](TrustResidentInUKPage)
+
+    beRemovable[Boolean](TrustResidentInUKPage)
+  }
+}

--- a/test/pages/TrustResidentOffshorePageSpec.scala
+++ b/test/pages/TrustResidentOffshorePageSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import pages.behaviours.PageBehaviours

--- a/test/pages/TrustResidentOffshorePageSpec.scala
+++ b/test/pages/TrustResidentOffshorePageSpec.scala
@@ -1,0 +1,15 @@
+package pages
+
+import pages.behaviours.PageBehaviours
+
+class TrustResidentOffshorePageSpec extends PageBehaviours {
+
+  "TrustResidentOffshorePage" must {
+
+    beRetrievable[Boolean](TrustResidentOffshorePage)
+
+    beSettable[Boolean](TrustResidentOffshorePage)
+
+    beRemovable[Boolean](TrustResidentOffshorePage)
+  }
+}

--- a/test/pages/WhenTrustSetupPageSpec.scala
+++ b/test/pages/WhenTrustSetupPageSpec.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +12,27 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import viewmodels.AnswerRow
+package pages
 
-@(row: AnswerRow)(implicit messages: Messages)
+import java.time.LocalDate
 
-<li>
-    <div class="cya-question">@messages(row.label)</div>
-    <div class="cya-answer">
-        @row.answer
-    </div>
-    <div class="cya-change">
-        <a href='@row.changeUrl'>
-            <span aria-hidden="true">@messages("site.edit")</span>
-            <span class="visually-hidden">@messages("site.hidden-edit", messages(row.label))</span>
-        </a>
-    </div>
-</li>
+import org.scalacheck.Arbitrary
+import pages.behaviours.PageBehaviours
+
+class WhenTrustSetupPageSpec extends PageBehaviours {
+
+  "WhenTrustSetupPage" must {
+
+    implicit lazy val arbitraryLocalDate: Arbitrary[LocalDate] = Arbitrary {
+      datesBetween(LocalDate.of(1900, 1, 1), LocalDate.of(2100, 1, 1))
+    }
+
+    beRetrievable[LocalDate](WhenTrustSetupPage)
+
+    beSettable[LocalDate](WhenTrustSetupPage)
+
+    beRemovable[LocalDate](WhenTrustSetupPage)
+  }
+}

--- a/test/views/AdministrationOutsideUKViewSpec.scala
+++ b/test/views/AdministrationOutsideUKViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/AdministrationOutsideUKViewSpec.scala
+++ b/test/views/AdministrationOutsideUKViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.AdministrationOutsideUKFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.AdministrationOutsideUKView
+
+class AdministrationOutsideUKViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "administrationOutsideUK"
+
+  val form = new AdministrationOutsideUKFormProvider()()
+
+  "AdministrationOutsideUK view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[AdministrationOutsideUKView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.AdministrationOutsideUKController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/AgentOtherThanBarristerViewSpec.scala
+++ b/test/views/AgentOtherThanBarristerViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.AgentOtherThanBarristerFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.AgentOtherThanBarristerView
+
+class AgentOtherThanBarristerViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "agentOtherThanBarrister"
+
+  val form = new AgentOtherThanBarristerFormProvider()()
+
+  "AgentOtherThanBarrister view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[AgentOtherThanBarristerView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.AgentOtherThanBarristerController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/AgentOtherThanBarristerViewSpec.scala
+++ b/test/views/AgentOtherThanBarristerViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/CountryAdministeringTrustViewSpec.scala
+++ b/test/views/CountryAdministeringTrustViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/CountryAdministeringTrustViewSpec.scala
+++ b/test/views/CountryAdministeringTrustViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.CountryAdministeringTrustFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.StringViewBehaviours
+import views.html.CountryAdministeringTrustView
+
+class CountryAdministeringTrustViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "countryAdministeringTrust"
+
+  val form = new CountryAdministeringTrustFormProvider()()
+
+  "CountryAdministeringTrustView view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[CountryAdministeringTrustView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like stringPage(form, applyView, messageKeyPrefix, routes.CountryAdministeringTrustController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/CountryGoverningTrustViewSpec.scala
+++ b/test/views/CountryGoverningTrustViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/CountryGoverningTrustViewSpec.scala
+++ b/test/views/CountryGoverningTrustViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.CountryGoverningTrustFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.StringViewBehaviours
+import views.html.CountryGoverningTrustView
+
+class CountryGoverningTrustViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "countryGoverningTrust"
+
+  val form = new CountryGoverningTrustFormProvider()()
+
+  "CountryGoverningTrustView view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[CountryGoverningTrustView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like stringPage(form, applyView, messageKeyPrefix, routes.CountryGoverningTrustController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/EstablishedUnderScotsLawViewSpec.scala
+++ b/test/views/EstablishedUnderScotsLawViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.EstablishedUnderScotsLawFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.EstablishedUnderScotsLawView
+
+class EstablishedUnderScotsLawViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "establishedUnderScotsLaw"
+
+  val form = new EstablishedUnderScotsLawFormProvider()()
+
+  "EstablishedUnderScotsLaw view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[EstablishedUnderScotsLawView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.EstablishedUnderScotsLawController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/EstablishedUnderScotsLawViewSpec.scala
+++ b/test/views/EstablishedUnderScotsLawViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/GovernedOutsideTheUKViewSpec.scala
+++ b/test/views/GovernedOutsideTheUKViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/GovernedOutsideTheUKViewSpec.scala
+++ b/test/views/GovernedOutsideTheUKViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.GovernedOutsideTheUKFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.GovernedOutsideTheUKView
+
+class GovernedOutsideTheUKViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "governedOutsideTheUK"
+
+  val form = new GovernedOutsideTheUKFormProvider()()
+
+  "GovernedOutsideTheUK view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[GovernedOutsideTheUKView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.GovernedOutsideTheUKController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/InheritanceTaxActViewSpec.scala
+++ b/test/views/InheritanceTaxActViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/InheritanceTaxActViewSpec.scala
+++ b/test/views/InheritanceTaxActViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.InheritanceTaxActFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.InheritanceTaxActView
+
+class InheritanceTaxActViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "inheritanceTaxAct"
+
+  val form = new InheritanceTaxActFormProvider()()
+
+  "InheritanceTaxAct view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[InheritanceTaxActView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.InheritanceTaxActController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/Non-residentTypeViewSpec.scala
+++ b/test/views/Non-residentTypeViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import forms.Non-residentTypeFormProvider

--- a/test/views/Non-residentTypeViewSpec.scala
+++ b/test/views/Non-residentTypeViewSpec.scala
@@ -1,0 +1,61 @@
+package views
+
+import forms.Non-residentTypeFormProvider
+import models.{NormalMode, Non-residentType}
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.ViewBehaviours
+import views.html.Non-residentTypeView
+
+class Non-residentTypeViewSpec extends ViewBehaviours {
+
+  val messageKeyPrefix = "non-residentType"
+
+  val form = new Non-residentTypeFormProvider()()
+
+  val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+  val view = application.injector.instanceOf[Non-residentTypeView]
+
+  def applyView(form: Form[_]): HtmlFormat.Appendable =
+    view.apply(form, NormalMode)(fakeRequest, messages)
+
+  "Non-residentTypeView" must {
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+  }
+
+  "Non-residentTypeView" when {
+
+    "rendered" must {
+
+      "contain radio buttons for the value" in {
+
+        val doc = asDocument(applyView(form))
+
+        for (option <- Non-residentType.options) {
+          assertContainsRadioButton(doc, option.id, "value", option.value, false)
+        }
+      }
+    }
+
+    for (option <- Non-residentType.options) {
+
+      s"rendered with a value of '${option.value}'" must {
+
+        s"have the '${option.value}' radio button selected" in {
+
+          val doc = asDocument(applyView(form.bind(Map("value" -> s"${option.value}"))))
+
+          assertContainsRadioButton(doc, option.id, "value", option.value, true)
+
+          for (unselectedOption <- Non-residentType.options.filterNot(o => o == option)) {
+            assertContainsRadioButton(doc, unselectedOption.id, "value", unselectedOption.value, false)
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/views/NonResidentTypeViewSpec.scala
+++ b/test/views/NonResidentTypeViewSpec.scala
@@ -16,34 +16,34 @@
 
 package views
 
-import forms.Non-residentTypeFormProvider
-import models.{NormalMode, Non-residentType}
+import forms.NonResidentTypeFormProvider
+import models.{NormalMode, NonResidentType}
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.ViewBehaviours
-import views.html.Non-residentTypeView
+import views.html.NonResidentTypeView
 
-class Non-residentTypeViewSpec extends ViewBehaviours {
+class NonResidentTypeViewSpec extends ViewBehaviours {
 
-  val messageKeyPrefix = "non-residentType"
+  val messageKeyPrefix = "nonresidentType"
 
-  val form = new Non-residentTypeFormProvider()()
+  val form = new NonResidentTypeFormProvider()()
 
   val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-  val view = application.injector.instanceOf[Non-residentTypeView]
+  val view = application.injector.instanceOf[NonResidentTypeView]
 
   def applyView(form: Form[_]): HtmlFormat.Appendable =
     view.apply(form, NormalMode)(fakeRequest, messages)
 
-  "Non-residentTypeView" must {
+  "NonResidentTypeView" must {
 
     behave like normalPage(applyView(form), messageKeyPrefix)
 
     behave like pageWithBackLink(applyView(form))
   }
 
-  "Non-residentTypeView" when {
+  "NonResidentTypeView" when {
 
     "rendered" must {
 
@@ -51,13 +51,13 @@ class Non-residentTypeViewSpec extends ViewBehaviours {
 
         val doc = asDocument(applyView(form))
 
-        for (option <- Non-residentType.options) {
+        for (option <- NonResidentType.options) {
           assertContainsRadioButton(doc, option.id, "value", option.value, false)
         }
       }
     }
 
-    for (option <- Non-residentType.options) {
+    for (option <- NonResidentType.options) {
 
       s"rendered with a value of '${option.value}'" must {
 
@@ -67,7 +67,7 @@ class Non-residentTypeViewSpec extends ViewBehaviours {
 
           assertContainsRadioButton(doc, option.id, "value", option.value, true)
 
-          for (unselectedOption <- Non-residentType.options.filterNot(o => o == option)) {
+          for (unselectedOption <- NonResidentType.options.filterNot(o => o == option)) {
             assertContainsRadioButton(doc, unselectedOption.id, "value", unselectedOption.value, false)
           }
         }

--- a/test/views/RegisteringTrustFor5AViewSpec.scala
+++ b/test/views/RegisteringTrustFor5AViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.RegisteringTrustFor5AFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.RegisteringTrustFor5AView
+
+class RegisteringTrustFor5AViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "registeringTrustFor5A"
+
+  val form = new RegisteringTrustFor5AFormProvider()()
+
+  "RegisteringTrustFor5A view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[RegisteringTrustFor5AView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.RegisteringTrustFor5AController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/RegisteringTrustFor5AViewSpec.scala
+++ b/test/views/RegisteringTrustFor5AViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/TrustNameViewSpec.scala
+++ b/test/views/TrustNameViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.TrustNameFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.StringViewBehaviours
+import views.html.TrustNameView
+
+class TrustNameViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "trustName"
+
+  val form = new TrustNameFormProvider()()
+
+  "TrustNameView view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[TrustNameView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like stringPage(form, applyView, messageKeyPrefix, routes.TrustNameController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/TrustNameViewSpec.scala
+++ b/test/views/TrustNameViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/TrustPreviouslyResidentViewSpec.scala
+++ b/test/views/TrustPreviouslyResidentViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.TrustPreviouslyResidentFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.StringViewBehaviours
+import views.html.TrustPreviouslyResidentView
+
+class TrustPreviouslyResidentViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "trustPreviouslyResident"
+
+  val form = new TrustPreviouslyResidentFormProvider()()
+
+  "TrustPreviouslyResidentView view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[TrustPreviouslyResidentView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like stringPage(form, applyView, messageKeyPrefix, routes.TrustPreviouslyResidentController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/TrustPreviouslyResidentViewSpec.scala
+++ b/test/views/TrustPreviouslyResidentViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/TrustResidentInUKViewSpec.scala
+++ b/test/views/TrustResidentInUKViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/TrustResidentInUKViewSpec.scala
+++ b/test/views/TrustResidentInUKViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.TrustResidentInUKFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.TrustResidentInUKView
+
+class TrustResidentInUKViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "trustResidentInUK"
+
+  val form = new TrustResidentInUKFormProvider()()
+
+  "TrustResidentInUK view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[TrustResidentInUKView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.TrustResidentInUKController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/TrustResidentOffshoreViewSpec.scala
+++ b/test/views/TrustResidentOffshoreViewSpec.scala
@@ -1,0 +1,32 @@
+package views
+
+import controllers.routes
+import forms.TrustResidentOffshoreFormProvider
+import models.NormalMode
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.TrustResidentOffshoreView
+
+class TrustResidentOffshoreViewSpec extends YesNoViewBehaviours {
+
+  val messageKeyPrefix = "trustResidentOffshore"
+
+  val form = new TrustResidentOffshoreFormProvider()()
+
+  "TrustResidentOffshore view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[TrustResidentOffshoreView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, routes.TrustResidentOffshoreController.onSubmit(NormalMode).url)
+  }
+}

--- a/test/views/TrustResidentOffshoreViewSpec.scala
+++ b/test/views/TrustResidentOffshoreViewSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package views
 
 import controllers.routes

--- a/test/views/WhenTrustSetupViewSpec.scala
+++ b/test/views/WhenTrustSetupViewSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import java.time.LocalDate
+
+import forms.WhenTrustSetupFormProvider
+import models.{NormalMode, UserAnswers}
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.QuestionViewBehaviours
+import views.html.WhenTrustSetupView
+
+class WhenTrustSetupViewSpec extends QuestionViewBehaviours[LocalDate] {
+
+  val messageKeyPrefix = "whenTrustSetup"
+
+  val form = new WhenTrustSetupFormProvider()()
+
+  "WhenTrustSetupView view" must {
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    val view = application.injector.instanceOf[WhenTrustSetupView]
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, NormalMode)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+  }
+}


### PR DESCRIPTION
Adding pages and navigation for:

- Trust name
- Trust set up date
- Is trust governed by laws of a country outside the uk
- What is the country governing the trust
- Is the trust's general administration done outside the uk
- What is the country administrating the trust
- Is the trust resident in the uk
- Is the trust established under scots laws
- Was the trust previously resident offshore
- Where was the trust previously resident
- Registering for the purpose of schedule 5A
- Registering for purpose of inheritance tax
- Was is the non resident type
- Agent other than barrister
- Check your answers

This PR also includes changes to scaffold to remove Afaid and correct migration scripts.

Remaining in Trusts details 
- [ ] Content
- [ ] URLs
- [ ] Form validation
- [ ] Cleanup logic to remove fields from document in mongo from branching logic