### PR TITLE
TRUS-707 Generate characters without spaces

### DIFF
--- a/test/forms/TrusteesNameFormProviderSpec.scala
+++ b/test/forms/TrusteesNameFormProviderSpec.scala
@@ -79,7 +79,7 @@ class TrusteesNameFormProviderSpec extends StringFieldBehaviours {
     behave like optionalField(
       form,
       fieldName,
-      validDataGenerator =  RegexpGen.from(regex))
+      validDataGenerator = RegexpGen.from(regex))
   }
 
 

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -40,9 +40,10 @@ trait StringFieldBehaviours extends FieldBehaviours with OptionalFieldBehaviours
   }
 
   def fieldWithMaxLength(form: Form[_],
-                           fieldName: String,
-                           maxLength: Int,
-                           lengthError: FormError): Unit = {
+                         fieldName: String,
+                         maxLength: Int,
+                         lengthError: FormError
+                        ): Unit = {
 
     s"not bind strings longer than $maxLength characters" in {
 

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -91,11 +91,15 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
       chars <- listOfN(length, arbitrary[Char])
     } yield chars.mkString
 
-  def stringsLongerThan(minLength: Int): Gen[String] = for {
-    maxLength <- (minLength * 2).max(100)
-    length    <- Gen.chooseNum(minLength + 1, maxLength)
-    chars     <- listOfN(length, arbitrary[Char])
-  } yield chars.mkString
+  def stringsLongerThan(minLength: Int): Gen[String] = {
+    val gen = Gen.alphaNumChar
+
+    for {
+      maxLength <- (minLength * 2).max(100)
+      length    <- Gen.chooseNum(minLength + 1, maxLength)
+      chars     <- listOfN(length, gen)
+    } yield chars.mkString
+  }
 
   def stringsExceptSpecificValues(excluded: Set[String]): Gen[String] =
     nonEmptyString suchThat (!excluded.contains(_))


### PR DESCRIPTION
This ensures to pass trim() for field validation by generating strings without spaces.