### PR TITLE
Changes in Navigatorspec for Test failing to pass index value for valid input

### DIFF
--- a/test/navigation/navigators/AssetRoutes.scala
+++ b/test/navigation/navigators/AssetRoutes.scala
@@ -42,8 +42,10 @@ trait AssetRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
 
+          val assets = userAnswers.get(Assets).getOrElse(List.empty)
+
           navigator.nextPage(AssetMoneyValuePage(index), NormalMode)(userAnswers)
-            .mustBe(routes.WhatKindOfAssetController.onPageLoad(NormalMode, index))
+            .mustBe(routes.WhatKindOfAssetController.onPageLoad(NormalMode, assets.size))
 
       }
     }


### PR DESCRIPTION
Current Test is failing for navigating to WhatKindOfAssetPage from AssetMoneyValuePage when the amount submitted because, it always pass index value = 0, where actually it should pass the assets collection size.