### PR TITLE
Adding in require draft registration refiner to stop multiple registrations

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -27,11 +27,12 @@ class Module extends AbstractModule {
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
     bind(classOf[DraftIdRetrievalActionProvider]).to(classOf[DraftIdDataRetrievalActionProviderImpl]).asEagerSingleton()
+    bind(classOf[RequireDraftRegistrationActionRefiner]).to(classOf[RequireDraftRegistrationActionRefinerImpl]).asEagerSingleton()
 
     // For session based storage instead of cred based, change to SessionIdentifierAction
     bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()
 
-    bind(classOf[RegistrationCompleteActionRefiner]).to(classOf[RegistrationCompleteActionRefinerImpl]).asEagerSingleton()
+    bind(classOf[TaskListCompleteActionRefiner]).to(classOf[TaskListCompleteActionRefinerImpl]).asEagerSingleton()
 
     bind(classOf[RequiredAgentAffinityGroupActionProvider]).to(classOf[RequireStateActionProviderImpl]).asEagerSingleton()
 

--- a/app/controllers/ConfirmationAnswerPageController.scala
+++ b/app/controllers/ConfirmationAnswerPageController.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 
 import controllers.actions._
 import javax.inject.Inject
-import pages.{RegistrationProgress, RegistrationSubmissionDatePage, RegistrationTRNPage}
+import pages.{RegistrationSubmissionDatePage, RegistrationTRNPage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
@@ -37,8 +37,7 @@ class ConfirmationAnswerPageController @Inject()(
                                               val controllerComponents: MessagesControllerComponents,
                                               view: ConfirmationAnswerPageView,
                                               countryOptions : CountryOptions,
-                                              registrationProgress: RegistrationProgress,
-                                              registrationComplete : RegistrationCompleteActionRefiner
+                                              registrationComplete : TaskListCompleteActionRefiner
                                             ) extends FrontendBaseController with I18nSupport {
 
   private def actions(draftId : String) =

--- a/app/controllers/ConfirmationController.scala
+++ b/app/controllers/ConfirmationController.scala
@@ -64,7 +64,7 @@ class ConfirmationController @Inject()(
     }
   }
 
-  def onPageLoad(draftId: String): Action[AnyContent] = (identify andThen getData(draftId, models.RegistrationProgress.Complete) andThen requireData).async {
+  def onPageLoad(draftId: String): Action[AnyContent] = (identify andThen getData(draftId) andThen requireData).async {
     implicit request =>
       val userAnswers = request.userAnswers
 

--- a/app/controllers/DeclarationController.scala
+++ b/app/controllers/DeclarationController.scala
@@ -48,12 +48,13 @@ class DeclarationController @Inject()(
                                        val controllerComponents: MessagesControllerComponents,
                                        view: DeclarationView,
                                        submissionService: SubmissionService,
-                                       registrationComplete : RegistrationCompleteActionRefiner
+                                       registrationComplete : TaskListCompleteActionRefiner,
+                                       requireDraft : RequireDraftRegistrationActionRefiner
                                     )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 
-  def actions(draftId: String) = identify andThen getData(draftId) andThen requireData andThen registrationComplete
+  def actions(draftId: String) = identify andThen getData(draftId) andThen requireData andThen registrationComplete andThen requireDraft
 
   def onPageLoad(mode: Mode, draftId: String): Action[AnyContent] = actions(draftId) {
     implicit request =>

--- a/app/controllers/SummaryAnswerPageController.scala
+++ b/app/controllers/SummaryAnswerPageController.scala
@@ -37,7 +37,7 @@ class SummaryAnswerPageController @Inject()(
                                               view: SummaryAnswerPageView,
                                               countryOptions : CountryOptions,
                                               registrationProgress: RegistrationProgress,
-                                              registrationComplete : RegistrationCompleteActionRefiner
+                                              registrationComplete : TaskListCompleteActionRefiner
                                             ) extends FrontendBaseController with I18nSupport {
 
   private def actions(draftId : String) =

--- a/app/controllers/TaskListController.scala
+++ b/app/controllers/TaskListController.scala
@@ -47,7 +47,8 @@ class TaskListController @Inject()(
                                        config: FrontendAppConfig,
                                        registrationProgress: RegistrationProgress,
                                        sessionRepository: SessionRepository,
-                                       taskListNavigator : TaskListNavigator
+                                       taskListNavigator : TaskListNavigator,
+                                       requireDraft : RequireDraftRegistrationActionRefiner
                                      )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   private def actions(draftId: String) =
@@ -59,7 +60,7 @@ class TaskListController @Inject()(
       requiredAnswer(
         RequiredAnswer(
           TrustHaveAUTRPage, routes.TrustHaveAUTRController.onPageLoad(NormalMode, draftId))
-      )
+      ) andThen requireDraft
 
   def onPageLoad(draftId: String): Action[AnyContent] = actions(draftId).async {
     implicit request =>

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -39,7 +39,7 @@ class DataRetrievalActionImpl @Inject()(val sessionRepository: SessionRepository
           case None =>
             Future.successful(createdOptionalDataRequest(request, None))
           case Some(userAnswer) =>
-            sessionRepository.get(userAnswer.draftId, userAnswer.internalAuthId, RegistrationProgress.InProgress).map {
+            sessionRepository.get(userAnswer.draftId, userAnswer.internalAuthId).map {
               case None =>
                 createdOptionalDataRequest(request, None)
               case Some(userAnswers) =>

--- a/app/controllers/actions/DraftIdRetrievalAction.scala
+++ b/app/controllers/actions/DraftIdRetrievalAction.scala
@@ -27,21 +27,20 @@ import scala.concurrent.{ExecutionContext, Future}
 class DraftIdDataRetrievalActionProviderImpl @Inject()(sessionRepository: SessionRepository, executionContext: ExecutionContext)
   extends DraftIdRetrievalActionProvider {
 
-  def apply(draftId: String, status : RegistrationProgress): DraftIdDataRetrievalAction =
-    new DraftIdDataRetrievalAction(draftId, status,sessionRepository, executionContext)
+  def apply(draftId: String): DraftIdDataRetrievalAction =
+    new DraftIdDataRetrievalAction(draftId, sessionRepository, executionContext)
 
 }
 
 class DraftIdDataRetrievalAction(
                                   draftId : String,
-                                  status : RegistrationProgress,
                                   sessionRepository: SessionRepository,
                                   implicit protected val executionContext: ExecutionContext
                                 )
   extends ActionTransformer[IdentifierRequest, OptionalDataRequest] {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
-    sessionRepository.get(draftId, request.identifier,status).map {
+    sessionRepository.get(draftId, request.identifier).map {
       userAnswers =>
         OptionalDataRequest(request.request, request.identifier, userAnswers, request.affinityGroup, request.agentARN)
     }
@@ -51,6 +50,6 @@ class DraftIdDataRetrievalAction(
 
 trait DraftIdRetrievalActionProvider {
 
-  def apply(draftId : String, status : RegistrationProgress = RegistrationProgress.InProgress) : DraftIdDataRetrievalAction
+  def apply(draftId : String) : DraftIdDataRetrievalAction
 
 }

--- a/app/controllers/actions/RequireDraftRegistrationActionRefiner.scala
+++ b/app/controllers/actions/RequireDraftRegistrationActionRefiner.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import controllers.routes
+import javax.inject.Inject
+import models.RegistrationProgress.Complete
+import models.requests.DataRequest
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{ActionRefiner, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class RequireDraftRegistrationActionRefinerImpl @Inject()(implicit val executionContext: ExecutionContext) extends RequireDraftRegistrationActionRefiner {
+
+  override protected def refine[A](request: DataRequest[A]): Future[Either[Result, DataRequest[A]]] = {
+    request.userAnswers.progress match {
+      case Complete =>
+        Future.successful(Left(Redirect(routes.ConfirmationController.onPageLoad(request.userAnswers.draftId))))
+      case _ =>
+        Future.successful(Right(request))
+    }
+  }
+}
+
+trait RequireDraftRegistrationActionRefiner extends ActionRefiner[DataRequest, DataRequest]

--- a/app/controllers/actions/TaskListCompleteActionRefiner.scala
+++ b/app/controllers/actions/TaskListCompleteActionRefiner.scala
@@ -25,10 +25,10 @@ import play.api.mvc.{ActionRefiner, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class RegistrationCompleteActionRefinerImpl @Inject()(
+class TaskListCompleteActionRefinerImpl @Inject()(
                                                      registrationProgress: RegistrationProgress,
                                                      implicit val executionContext: ExecutionContext
-                                                     ) extends RegistrationCompleteActionRefiner {
+                                                     ) extends TaskListCompleteActionRefiner {
 
   override protected def refine[A](request: DataRequest[A]): Future[Either[Result, DataRequest[A]]] = {
 
@@ -40,4 +40,4 @@ class RegistrationCompleteActionRefinerImpl @Inject()(
   }
 }
 
-trait RegistrationCompleteActionRefiner extends ActionRefiner[DataRequest, DataRequest]
+trait TaskListCompleteActionRefiner extends ActionRefiner[DataRequest, DataRequest]

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -402,7 +402,6 @@ class Navigator @Inject()() {
     case None => routes.SessionExpiredController.onPageLoad()
   }
 
-
   private def checkRouteMap(draftId: String): Page => UserAnswers => Call = {
     // TrustDetails
     case TrustNamePage => _ => routes.TrustDetailsAnswerPageController.onPageLoad(draftId)

--- a/app/repositories/SessionRepository.scala
+++ b/app/repositories/SessionRepository.scala
@@ -65,20 +65,12 @@ class DefaultSessionRepository @Inject()(
       }.map(_ => ())
     }
 
-  override def get(draftId: String, internalId: String, status : RegistrationProgress  ): Future[Option[UserAnswers]] = {
-  val selector =   status match {
-      case RegistrationProgress.Complete =>
-        Json.obj("_id" -> draftId,
-          "internalId" -> internalId,
-          "progress" -> status.toString
-        )
-      case _ =>
-        Json.obj("_id" -> draftId,
-          "internalId" -> internalId,
-          "progress" -> Json.obj("$ne" -> RegistrationProgress.Complete.toString)
-        )
+  override def get(draftId: String, internalId: String): Future[Option[UserAnswers]] = {
+      val selector = Json.obj(
+        "_id" -> draftId,
+        "internalId" -> internalId
+      )
 
-    }
       collection.flatMap(_.find(
         selector = selector, None).one[UserAnswers])
   }
@@ -139,7 +131,7 @@ trait SessionRepository {
 
   val started: Future[Unit]
 
-  def get(draftId: String, internalId: String,status : RegistrationProgress): Future[Option[UserAnswers]]
+  def get(draftId: String, internalId: String): Future[Option[UserAnswers]]
 
   def set(userAnswers: UserAnswers): Future[Boolean]
 

--- a/app/views/ConfirmationView.scala.html
+++ b/app/views/ConfirmationView.scala.html
@@ -45,9 +45,9 @@
 
         <h2>@messages("confirmationPage.subheading2")</h2>
 
-        <p>@messages("confirmationPage.new.paragraph2") @components.link(postHMRC, "contact-hmrc-for-utr", "confirmationPage.contacthmrc.link", "_blank")</p>
+        <p>@messages("confirmationPage.new.paragraph2") @components.link(postHMRC, "contact-hmrc-for-utr", "confirmationPage.contacthmrc.link", true)</p>
 
-        <p>@messages("confirmationPage.paragraph3") @components.link(postHMRC, "post-to-hmrc-contact", "confirmationPage.posthmrc.link", "_blank") @messages("confirmationPage.paragraph4")</p>
+        <p>@messages("confirmationPage.paragraph3") @components.link(postHMRC, "post-to-hmrc-contact", "confirmationPage.posthmrc.link", true) @messages("confirmationPage.paragraph4")</p>
 
     } else {
 
@@ -59,11 +59,11 @@
 
         <p>@messages("confirmationPage.existing.paragraph2")</p>
 
-        <p>@messages("confirmationPage.paragraph3") @components.link(postHMRC, "post-to-hmrc-contact", "confirmationPage.posthmrc.link", "_blank") @messages("confirmationPage.paragraph4")</p>
+        <p>@messages("confirmationPage.paragraph3") @components.link(postHMRC, "post-to-hmrc-contact", "confirmationPage.posthmrc.link", true) @messages("confirmationPage.paragraph4")</p>
     }
 
     @if(isAgent) {
-        @messages("confirmationPage.agent.you.can") @components.link(agentOverviewUrl, "agent-overview", "confirmationPage.agent.link", "_self")
+        @messages("confirmationPage.agent.you.can") @components.link(agentOverviewUrl, "agent-overview", "confirmationPage.agent.link", false)
     }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -147,8 +147,8 @@ POST       /:draftId/trustees/:index/change-date-of-birth    controllers.Trustee
 GET        /:draftId/trustees/:index/check-answers                      controllers.TrusteesAnswerPageController.onPageLoad(index : Int, draftId: String)
 POST       /:draftId/trustees/:index/check-answers                     controllers.TrusteesAnswerPageController.onSubmit(index : Int, draftId: String)
 
-GET        /:draftId/trustees/add/:draftId                                controllers.AddATrusteeController.onPageLoad(mode: Mode = NormalMode, draftId: String )
-POST       /:draftId/trustees/add/:draftId                                controllers.AddATrusteeController.onSubmit(mode: Mode = NormalMode, draftId: String)
+GET        /:draftId/trustees/add                                controllers.AddATrusteeController.onPageLoad(mode: Mode = NormalMode, draftId: String)
+POST       /:draftId/trustees/add                                controllers.AddATrusteeController.onSubmit(mode: Mode = NormalMode, draftId: String)
 
 GET        /:draftId/trustees/:index/telephone-number                        controllers.TelephoneNumberController.onPageLoad(mode: Mode = NormalMode, index : Int, draftId: String)
 POST       /:draftId/trustees/:index/telephone-number                        controllers.TelephoneNumberController.onSubmit(mode: Mode = NormalMode, index : Int, draftId: String)

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -58,7 +58,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutur
 
         val sessionRepository = mock[SessionRepository]
         when(sessionRepository.getDraftRegistrations("internalId")) thenReturn Future(List(emptyUserAnswers))
-        when(sessionRepository.get(draftId = any(), internalId = any(), status = any())) thenReturn Future(Some(emptyUserAnswers))
+        when(sessionRepository.get(draftId = any(), internalId = any())) thenReturn Future(Some(emptyUserAnswers))
         val action = new Harness(sessionRepository)
 
         val futureResult = action.callTransform(new IdentifierRequest(fakeRequest, "internalId", AffinityGroup.Individual))
@@ -71,7 +71,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutur
       "set userAnswers to 'None' because 'get' query returns 'None'" in {
         val sessionRepository = mock[SessionRepository]
         when(sessionRepository.getDraftRegistrations("internalId")) thenReturn Future(List(emptyUserAnswers))
-        when(sessionRepository.get(draftId = any(), internalId = any(), status = any())) thenReturn Future(None)
+        when(sessionRepository.get(draftId = any(), internalId = any())) thenReturn Future(None)
 
         val action = new Harness(sessionRepository)
 

--- a/test/controllers/actions/FakeDraftIdRetrievalActionProvider.scala
+++ b/test/controllers/actions/FakeDraftIdRetrievalActionProvider.scala
@@ -34,9 +34,9 @@ class FakeDraftIdRetrievalActionProvider(draftId: String,
 
   val mockedSession = mock[SessionRepository]
 
-  when(mockedSession.get(any(), any(),  any())).thenReturn(Future.successful(dataToReturn))
+  when(mockedSession.get(any(), any())).thenReturn(Future.successful(dataToReturn))
 
-  override def apply(draftId : String, status :  RegistrationProgress  ) = new DraftIdDataRetrievalAction(draftId,status ,mockedSession, executionContext)
+  override def apply(draftId : String) = new DraftIdDataRetrievalAction(draftId, mockedSession, executionContext)
 
 }
 

--- a/test/controllers/actions/RequireDraftRegistrationActionRefinerSpec.scala
+++ b/test/controllers/actions/RequireDraftRegistrationActionRefinerSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import controllers.routes
+import models.RegistrationProgress.{Complete, InProgress}
+import models.requests.DataRequest
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import play.api.http.HeaderNames
+import play.api.libs.json.Reads
+import play.api.mvc.Result
+import uk.gov.hmrc.auth.core.AffinityGroup
+import utils.TestUserAnswers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RequireDraftRegistrationActionRefinerSpec extends SpecBase with MockitoSugar with ScalaFutures with EitherValues {
+
+  class Harness()
+    extends RequireDraftRegistrationActionRefinerImpl {
+
+    def callRefine[A](request: DataRequest[A]): Future[Either[Result, DataRequest[A]]] = refine(request)
+  }
+
+  "require draft registration action" when {
+
+      "there is a complete registration" must {
+
+        "redirect to Confirmation by default" in {
+          val answers = TestUserAnswers.emptyUserAnswers.copy(progress = Complete)
+
+          val action = new Harness()
+          val futureResult = action.callRefine(new DataRequest(fakeRequest, "id", answers, AffinityGroup.Organisation))
+
+          whenReady(futureResult) { result =>
+            result.left.value.header.headers(HeaderNames.LOCATION) mustBe routes.ConfirmationController.onPageLoad(answers.draftId).url
+          }
+        }
+
+      }
+
+    "there is a non-complete registration" must {
+
+      "continue with refining the request" in {
+        val answers = TestUserAnswers.emptyUserAnswers.copy(progress = InProgress)
+
+        val dataRequest = new DataRequest(fakeRequest, "id", answers, AffinityGroup.Organisation)
+
+        val action = new Harness()
+        val futureResult = action.callRefine(dataRequest)
+
+        whenReady(futureResult) { result =>
+          result.right.value mustEqual dataRequest
+        }
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Removing status from `.get()` mongo API.
Fixing links that were opening in new tabs.