### PR TITLE
TRUS-1260 TXM audit events for CreatedDraft and CannotSubmitRegistration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/test.json
 *.bloop/
 *.metals
 .cache

--- a/app/connector/Headers.scala
+++ b/app/connector/Headers.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connector
+
+object Headers {
+
+  val DraftRegistrationId = "Draft-Registration-ID"
+
+}

--- a/app/connector/TrustConnector.scala
+++ b/app/connector/TrustConnector.scala
@@ -33,7 +33,7 @@ class TrustConnector @Inject()(http: HttpClient, config : FrontendAppConfig) {
   def register(registration: Registration, draftId : String)(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[TrustResponse] = {
 
     val newHc : HeaderCarrier = hc.withExtraHeaders(
-      "Draft-Registration-ID" -> draftId
+      Headers.DraftRegistrationId -> draftId
     )
 
     val response = http.POST[JsValue, TrustResponse](trustsEndpoint, Json.toJson(registration))(implicitly[Writes[JsValue]], TrustResponse.httpReads, newHc, ec)

--- a/app/connector/TrustConnector.scala
+++ b/app/connector/TrustConnector.scala
@@ -18,24 +18,25 @@ package connector
 
 import config.FrontendAppConfig
 import javax.inject.Inject
-
 import mapping.Registration
 import models.TrustResponse
 import play.api.libs.json.{JsValue, Json, Writes}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class TrustConnector @Inject()(http: HttpClient, config : FrontendAppConfig) {
 
   val trustsEndpoint = s"${config.trustsUrl}/trusts/register"
 
-  def register(registration: Registration)(implicit  hc:HeaderCarrier ): Future[TrustResponse] = {
+  def register(registration: Registration, draftId : String)(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[TrustResponse] = {
 
-    val response = http.POST[JsValue, TrustResponse](trustsEndpoint, Json.toJson(registration))
-    (implicitly[Writes[JsValue]], TrustResponse.httpReads, implicitly[HeaderCarrier](hc),global)
+    val newHc : HeaderCarrier = hc.withExtraHeaders(
+      "Draft-Registration-ID" -> draftId
+    )
+
+    val response = http.POST[JsValue, TrustResponse](trustsEndpoint, Json.toJson(registration))(implicitly[Writes[JsValue]], TrustResponse.httpReads, newHc, ec)
 
     response
   }

--- a/app/services/CreateDraftRegistrationService.scala
+++ b/app/services/CreateDraftRegistrationService.scala
@@ -34,6 +34,8 @@ class CreateDraftRegistrationService @Inject()(
                                               auditConnector: AuditConnector
                                               )(implicit ec: ExecutionContext, m: Materializer) {
 
+  import utils.implicits.MapImplicits._
+
   private def build[A](request: OptionalDataRequest[A])(implicit hc : HeaderCarrier) : Future[String] = {
     val draftId = UUID.randomUUID().toString
     val userAnswers = UserAnswers(draftId = draftId, internalAuthId = request.internalId)
@@ -41,12 +43,15 @@ class CreateDraftRegistrationService @Inject()(
     sessionRepository.set(userAnswers).map {
       _ =>
 
-        auditConnector.sendExplicitAudit(TrustAuditing.CREATE_DRAFT_EVENT, Map(
-          "draftId" -> draftId,
-          "internalAuthId" -> request.internalId,
-          "agentReferenceNumber" -> request.agentARN.getOrElse("Affinity group not Agent"),
-          "affinityGroup" -> request.affinityGroup.toString
-        ))
+        auditConnector.sendExplicitAudit(
+          TrustAuditing.CREATE_DRAFT_EVENT,
+          Map(
+            "draftId" -> draftId,
+            "internalAuthId" -> request.internalId,
+            "agentReferenceNumber" -> request.agentARN.getOrElse(""),
+            "affinityGroup" -> request.affinityGroup.toString
+          ).clean
+        )
 
         draftId
     }

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -42,7 +42,7 @@ class DefaultSubmissionService @Inject()(
     Logger.info("[SubmissionService][submit] submitting registration")
 
     registrationMapper.build(userAnswers) match {
-      case Some(registration) => trustConnector.register(registration)
+      case Some(registration) => trustConnector.register(registration, userAnswers.draftId)
       case None =>
 
         auditConnector.sendExplicitAudit(

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -22,7 +22,6 @@ import javax.inject.Inject
 import mapping.RegistrationMapper
 import models.{TrustResponse, UnableToRegister, UserAnswers}
 import play.api.Logger
-import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.TrustAuditing
@@ -46,12 +45,8 @@ class DefaultSubmissionService @Inject()(
       case None =>
 
         auditConnector.sendExplicitAudit(
-          TrustAuditing.CANNOT_CREATE_REGISTRATION,
-          Map(
-            "draftId" -> userAnswers.draftId,
-            "internalAuthId" -> userAnswers.internalAuthId,
-            "userAnswers" -> Json.stringify(Json.toJson(userAnswers))
-          )
+          TrustAuditing.CANNOT_SUBMIT_REGISTRATION,
+          userAnswers
         )
 
         Logger.warn("[SubmissionService][submit] Unable to generate registration to submit.")

--- a/app/utils/TrustAuditing.scala
+++ b/app/utils/TrustAuditing.scala
@@ -19,5 +19,6 @@ package utils
 object TrustAuditing {
 
   val CREATE_DRAFT_EVENT = "CreateDraftRegistration"
+  val CANNOT_CREATE_REGISTRATION = "CannotCreateRegistration"
 
 }

--- a/app/utils/TrustAuditing.scala
+++ b/app/utils/TrustAuditing.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+object TrustAuditing {
+
+  val CREATE_DRAFT_EVENT = "CreateDraftRegistration"
+
+}

--- a/app/utils/TrustAuditing.scala
+++ b/app/utils/TrustAuditing.scala
@@ -19,6 +19,6 @@ package utils
 object TrustAuditing {
 
   val CREATE_DRAFT_EVENT = "CreateDraftRegistration"
-  val CANNOT_CREATE_REGISTRATION = "CannotCreateRegistration"
+  val CANNOT_SUBMIT_REGISTRATION = "CannotSubmitRegistration"
 
 }

--- a/app/utils/implicits/MapImplicits.scala
+++ b/app/utils/implicits/MapImplicits.scala
@@ -1,0 +1,14 @@
+package utils.implicits
+
+
+object MapImplicits {
+
+  implicit class NonEmptyValueMap(x : Map[String, String]) {
+
+    def clean : Map[String, String] = {
+      x.filter {case (_, value) => value.nonEmpty}
+    }
+
+  }
+
+}

--- a/app/utils/implicits/MapImplicits.scala
+++ b/app/utils/implicits/MapImplicits.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils.implicits
 
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -107,8 +107,7 @@ metrics {
 }
 
 auditing {
-  enabled=false
-  traceRequests=true
+  enabled = true
   consumer {
     baseUri {
       host = localhost

--- a/test/base/Mocked.scala
+++ b/test/base/Mocked.scala
@@ -23,20 +23,28 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.mvc.AnyContent
 import repositories.SessionRepository
 import services.{CreateDraftRegistrationService, SubmissionService}
+import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
 import utils.TestUserAnswers
 
 import scala.concurrent.Future
 
 trait Mocked extends MockitoSugar {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   val mockedSessionRepository : SessionRepository = mock[SessionRepository]
   val mockSubmissionService : SubmissionService = mock[SubmissionService]
   val mockCreateDraftRegistrationService : CreateDraftRegistrationService = mock[CreateDraftRegistrationService]
+  val mockedAuditConnector : AuditConnector = mock[AuditConnector]
 
-  when(mockCreateDraftRegistrationService.create(any[OptionalDataRequest[AnyContent]]))
+  when(mockedAuditConnector.sendExtendedEvent(any[ExtendedDataEvent]))
+    .thenReturn(Future.successful(AuditResult.Success))
+
+  when(mockCreateDraftRegistrationService.create(any[OptionalDataRequest[AnyContent]])(any()))
     .thenReturn(Future.successful(TestUserAnswers.draftId))
 
-  when(mockCreateDraftRegistrationService.create(any[IdentifierRequest[AnyContent]]))
+  when(mockCreateDraftRegistrationService.create(any[IdentifierRequest[AnyContent]])(any()))
       .thenReturn(Future.successful(TestUserAnswers.draftId))
 
   when(mockedSessionRepository.set(any())).thenReturn(Future.successful(true))

--- a/test/connector/TrustConnectorSpec.scala
+++ b/test/connector/TrustConnectorSpec.scala
@@ -17,10 +17,10 @@
 package connector
 
 import base.SpecBaseHelpers
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, containing, equalTo, post, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import generators.Generators
 import mapping.{Mapping, Registration, RegistrationMapper}
-import models.{AlreadyRegistered, InternalServerError, RegistrationTRNResponse, TrustResponse}
+import models.{AlreadyRegistered, InternalServerError, RegistrationTRNResponse}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
 import play.api.Application
@@ -31,8 +31,10 @@ import play.api.test.Helpers.CONTENT_TYPE
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{TestUserAnswers, WireMockHelper}
 
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class TrustConnectorSpec extends FreeSpec with MustMatchers
   with OptionValues with Generators with SpecBaseHelpers with WireMockHelper with ScalaFutures {
@@ -92,7 +94,7 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
           """.stripMargin
         )
 
-        val result  = Await.result(connector.register(registration),Duration.Inf)
+        val result  = Await.result(connector.register(registration, TestUserAnswers.draftId),Duration.Inf)
         result mustBe RegistrationTRNResponse("XTRN1234567")
       }
     }
@@ -116,7 +118,7 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
                              """.stripMargin
         )
 
-        val result  = Await.result(connector.register(registration),Duration.Inf)
+        val result  = Await.result(connector.register(registration, TestUserAnswers.draftId),Duration.Inf)
         result mustBe AlreadyRegistered
       }
     }
@@ -139,7 +141,7 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
                              """.stripMargin
         )
 
-        val result  = Await.result(connector.register(registration),Duration.Inf)
+        val result  = Await.result(connector.register(registration, TestUserAnswers.draftId),Duration.Inf)
         result mustBe InternalServerError
       }
     }
@@ -157,7 +159,7 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
           expectedResponse = ""
         )
 
-        val result  = Await.result(connector.register(registration),Duration.Inf)
+        val result  = Await.result(connector.register(registration, TestUserAnswers.draftId),Duration.Inf)
         result mustBe InternalServerError
       }
     }
@@ -175,7 +177,7 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
           expectedResponse = ""
         )
 
-        val result  = Await.result(connector.register(registration),Duration.Inf)
+        val result  = Await.result(connector.register(registration, TestUserAnswers.draftId),Duration.Inf)
         result mustBe InternalServerError
       }
     }

--- a/test/controllers/DeclarationControllerSpec.scala
+++ b/test/controllers/DeclarationControllerSpec.scala
@@ -153,7 +153,7 @@ class DeclarationControllerSpec extends SpecBase {
           )
         )
 
-      when(mockSubmissionService.submit(any[UserAnswers])(any[HeaderCarrier])).
+      when(mockSubmissionService.submit(any[UserAnswers])(any[HeaderCarrier], any())).
         thenReturn(Future.successful(RegistrationTRNResponse("xTRN12456")))
 
       val application =
@@ -169,7 +169,7 @@ class DeclarationControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.ConfirmationController.onPageLoad(userAnswersId).url
-      verify(mockSubmissionService, times(1)).submit(any[UserAnswers])(any[HeaderCarrier])
+      verify(mockSubmissionService, times(1)).submit(any[UserAnswers])(any[HeaderCarrier], any())
       application.stop()
     }
 
@@ -182,7 +182,7 @@ class DeclarationControllerSpec extends SpecBase {
           )
         )
 
-      when(mockSubmissionService.submit(any[UserAnswers])(any[HeaderCarrier])).
+      when(mockSubmissionService.submit(any[UserAnswers])(any[HeaderCarrier], any())).
         thenReturn(Future.failed(UnableToRegister()))
 
       val application =
@@ -198,7 +198,7 @@ class DeclarationControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.TaskListController.onPageLoad(fakeDraftId).url
-      verify(mockSubmissionService, times(1)).submit(any[UserAnswers])(any[HeaderCarrier])
+      verify(mockSubmissionService, times(1)).submit(any[UserAnswers])(any[HeaderCarrier], any())
       application.stop()
     }
 
@@ -211,7 +211,7 @@ class DeclarationControllerSpec extends SpecBase {
           )
         )
 
-      when(mockSubmissionService.submit(any[UserAnswers])(any[HeaderCarrier])).
+      when(mockSubmissionService.submit(any[UserAnswers])(any[HeaderCarrier], any())).
         thenReturn(Future.successful(AlreadyRegistered))
 
 
@@ -228,7 +228,7 @@ class DeclarationControllerSpec extends SpecBase {
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.UTRSentByPostController.onPageLoad().url
-      verify(mockSubmissionService, times(1)).submit(any[UserAnswers])(any[HeaderCarrier])
+      verify(mockSubmissionService, times(1)).submit(any[UserAnswers])(any[HeaderCarrier], any())
       application.stop()
     }
 

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -19,18 +19,17 @@ package services
 import base.SpecBaseHelpers
 import connector.TrustConnector
 import generators.Generators
-import mapping.{Mapping, Registration, RegistrationMapper}
+import mapping.{Registration, RegistrationMapper}
 import models.{RegistrationTRNResponse, UnableToRegister}
-import org.mockito.Mockito.when
 import org.mockito.Matchers.any
-
-
-import org.scalatest.{AsyncFreeSpec, FreeSpec, MustMatchers, OptionValues}
+import org.mockito.Mockito.when
+import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.TestUserAnswers
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class SubmissionServiceSpec extends FreeSpec with MustMatchers
   with OptionValues with Generators with SpecBaseHelpers
@@ -40,7 +39,7 @@ class SubmissionServiceSpec extends FreeSpec with MustMatchers
 
   val mockConnector = mock[TrustConnector]
 
-  val submissionService = new DefaultSubmissionService(registrationMapper,mockConnector)
+  val submissionService = new DefaultSubmissionService(registrationMapper,mockConnector, mockedAuditConnector)
 
   implicit lazy val hc: HeaderCarrier = HeaderCarrier()
 

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -63,7 +63,7 @@ class SubmissionServiceSpec extends FreeSpec with MustMatchers
 
         val userAnswers = newTrustUserAnswers
 
-        when(mockConnector.register(any[Registration])(any[HeaderCarrier])).
+        when(mockConnector.register(any[Registration], any())(any[HeaderCarrier], any())).
           thenReturn(Future.successful(RegistrationTRNResponse("XTRN1234567")))
 
         val result  = Await.result(submissionService.submit(userAnswers),Duration.Inf)
@@ -74,7 +74,7 @@ class SubmissionServiceSpec extends FreeSpec with MustMatchers
 
         val userAnswers = TestUserAnswers.withAgent(newTrustUserAnswers)
 
-        when(mockConnector.register(any[Registration])(any[HeaderCarrier])).
+        when(mockConnector.register(any[Registration], any())(any[HeaderCarrier], any())).
           thenReturn(Future.successful(RegistrationTRNResponse("XTRN1234567")))
 
         val result  = Await.result(submissionService.submit(userAnswers),Duration.Inf)


### PR DESCRIPTION
Auditing out the body of the payload when we've been unable to construct a `Registration` object due to an error with the data.
Auditing out when a new draft registration has been created in mongo.