### PR TITLE
Remove pages now render correctly when no identifier provided

### DIFF
--- a/app/controllers/RemoveClassOfBeneficiaryController.scala
+++ b/app/controllers/RemoveClassOfBeneficiaryController.scala
@@ -23,7 +23,7 @@ import models.requests.DataRequest
 import models.{Mode, NormalMode}
 import pages.{ClassBeneficiaryDescriptionPage, IndividualBeneficiaryNamePage, QuestionPage}
 import play.api.data.Form
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import queries.{RemoveClassOfBeneficiaryQuery, RemoveIndividualBeneficiaryQuery, Settable}
@@ -49,9 +49,7 @@ class RemoveClassOfBeneficiaryController @Inject()(
   override def page(index: Int): QuestionPage[String] = ClassBeneficiaryDescriptionPage(index)
 
   override def actions(draftId : String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def redirect(draftId : String) : Call =
     routes.AddABeneficiaryController.onPageLoad(draftId)
@@ -62,11 +60,6 @@ class RemoveClassOfBeneficiaryController @Inject()(
   override def removeQuery(index: Int): Settable[_] = RemoveClassOfBeneficiaryQuery(index)
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]) : String =
-    request.userAnswers.get(page(index)).get
-
-  override def view(form: Form[_], index: Int, draftId: String)
-                   (implicit request: DataRequest[AnyContent], messagesApi: MessagesApi): HtmlFormat.Appendable = {
-    removeView(messagesPrefix, form, index, draftId, content(index), formRoute(draftId, index))
-  }
+    request.userAnswers.get(page(index)).map(_.toString).getOrElse(Messages(s"$messagesPrefix.default"))
 
 }

--- a/app/controllers/RemoveIndividualBeneficiaryController.scala
+++ b/app/controllers/RemoveIndividualBeneficiaryController.scala
@@ -23,7 +23,7 @@ import models.{FullName, Mode, NormalMode}
 import models.requests.DataRequest
 import pages.{IndividualBeneficiaryNamePage, QuestionPage}
 import play.api.data.Form
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import queries.{RemoveIndividualBeneficiaryQuery, Settable}
@@ -49,9 +49,7 @@ class RemoveIndividualBeneficiaryController @Inject()(
   override def page(index: Int): QuestionPage[FullName] = IndividualBeneficiaryNamePage(index)
 
   override def actions(draftId : String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def redirect(draftId : String) : Call =
     routes.AddABeneficiaryController.onPageLoad(draftId)
@@ -62,11 +60,6 @@ class RemoveIndividualBeneficiaryController @Inject()(
   override def removeQuery(index: Int): Settable[_] = RemoveIndividualBeneficiaryQuery(index)
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]) : String =
-    request.userAnswers.get(page(index)).get.toString
-
-  override def view(form: Form[_], index: Int, draftId: String)
-                   (implicit request: DataRequest[AnyContent], messagesApi: MessagesApi): HtmlFormat.Appendable = {
-    removeView(messagesPrefix, form, index, draftId, content(index), formRoute(draftId, index))
-  }
+    request.userAnswers.get(page(index)).map(_.toString).getOrElse(Messages(s"$messagesPrefix.default"))
 
 }

--- a/app/controllers/RemoveTrusteeController.scala
+++ b/app/controllers/RemoveTrusteeController.scala
@@ -23,7 +23,7 @@ import models.FullName
 import models.requests.DataRequest
 import pages.{QuestionPage, TrusteesNamePage}
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import queries.{RemoveTrusteeQuery, Settable}
@@ -48,10 +48,8 @@ class RemoveTrusteeController @Inject()(
 
   override def page(index: Int) : QuestionPage[FullName] = TrusteesNamePage(index)
 
-  def actions(draftId : String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+  override def actions(draftId : String, index: Int) =
+    identify andThen getData(draftId) andThen requireData
 
   override def redirect(draftId : String) : Call =
     routes.AddATrusteeController.onPageLoad(draftId)
@@ -62,10 +60,6 @@ class RemoveTrusteeController @Inject()(
   override def removeQuery(index: Int): Settable[_] = RemoveTrusteeQuery(index)
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]) : String =
-    request.userAnswers.get(page(index)).get.toString
+    request.userAnswers.get(page(index)).map(_.toString).getOrElse(Messages(s"$messagesPrefix.default"))
 
-  override def view(form: Form[_], index: Int, draftId: String)
-                   (implicit request: DataRequest[AnyContent], messagesApi: MessagesApi): HtmlFormat.Appendable = {
-    removeView(messagesPrefix, form, index, draftId, content(index), formRoute(draftId, index))
-  }
 }

--- a/app/controllers/money/RemoveMoneyAssetController.scala
+++ b/app/controllers/money/RemoveMoneyAssetController.scala
@@ -22,7 +22,7 @@ import forms.RemoveIndexFormProvider
 import javax.inject.Inject
 import models.requests.DataRequest
 import pages.{AssetMoneyValuePage, QuestionPage}
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Call, MessagesControllerComponents}
 import repositories.SessionRepository
 import views.html.RemoveIndexView
@@ -44,12 +44,11 @@ class RemoveMoneyAssetController @Inject()(
   override val messagesPrefix : String = "removeMoneyAsset"
 
   override def actions(draftId : String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]) : String =
-    s"£${request.userAnswers.get(page(index)).get}"
+    request.userAnswers.get(page(index)).map(x => s"£$x")
+      .getOrElse(Messages(s"$messagesPrefix.default"))
 
   override def formRoute(draftId: String, index: Int): Call =
     controllers.money.routes.RemoveMoneyAssetController.onSubmit(index, draftId)

--- a/app/controllers/property_or_land/RemovePropertyOrLandWithAddressInternationalController.scala
+++ b/app/controllers/property_or_land/RemovePropertyOrLandWithAddressInternationalController.scala
@@ -24,7 +24,7 @@ import models.InternationalAddress
 import models.requests.DataRequest
 import pages.QuestionPage
 import pages.property_or_land.PropertyOrLandInternationalAddressPage
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Call, MessagesControllerComponents}
 import repositories.SessionRepository
 import views.html.RemoveIndexView
@@ -44,14 +44,12 @@ class RemovePropertyOrLandWithAddressInternationalController @Inject()(
   override val messagesPrefix: String = "removePropertyOrLandAsset"
 
   override def actions(draftId: String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def page(index: Int): QuestionPage[InternationalAddress] = PropertyOrLandInternationalAddressPage(index)
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]): String =
-    request.userAnswers.get(page(index)).get.line1
+    request.userAnswers.get(page(index)).map(_.line1).getOrElse(Messages(s"$messagesPrefix.default"))
 
   override def formRoute(draftId: String, index: Int): Call =
     controllers.property_or_land.routes.RemovePropertyOrLandWithAddressInternationalController.onSubmit(index, draftId)

--- a/app/controllers/property_or_land/RemovePropertyOrLandWithAddressUKController.scala
+++ b/app/controllers/property_or_land/RemovePropertyOrLandWithAddressUKController.scala
@@ -24,7 +24,7 @@ import models.UKAddress
 import models.requests.DataRequest
 import pages.QuestionPage
 import pages.property_or_land.PropertyOrLandUKAddressPage
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Call, MessagesControllerComponents}
 import repositories.SessionRepository
 import views.html.RemoveIndexView
@@ -44,14 +44,12 @@ class RemovePropertyOrLandWithAddressUKController @Inject()(
   override val messagesPrefix: String = "removePropertyOrLandAsset"
 
   override def actions(draftId: String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def page(index: Int): QuestionPage[UKAddress] = PropertyOrLandUKAddressPage(index)
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]): String =
-    request.userAnswers.get(page(index)).get.line1
+    request.userAnswers.get(page(index)).map(_.line1).getOrElse(Messages(s"$messagesPrefix.default"))
 
   override def formRoute(draftId: String, index: Int): Call =
     controllers.property_or_land.routes.RemovePropertyOrLandWithAddressUKController.onSubmit(index, draftId)

--- a/app/controllers/property_or_land/RemovePropertyOrLandWithDescriptionController.scala
+++ b/app/controllers/property_or_land/RemovePropertyOrLandWithDescriptionController.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import models.requests.DataRequest
 import pages.QuestionPage
 import pages.property_or_land.PropertyOrLandDescriptionPage
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Call, MessagesControllerComponents}
 import repositories.SessionRepository
 import views.html.RemoveIndexView
@@ -43,14 +43,12 @@ class RemovePropertyOrLandWithDescriptionController @Inject()(
   override val messagesPrefix: String = "removePropertyOrLandAsset"
 
   override def actions(draftId: String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def page(index: Int): QuestionPage[String] = PropertyOrLandDescriptionPage(index)
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]): String =
-    request.userAnswers.get(page(index)).get
+    request.userAnswers.get(page(index)).getOrElse(Messages(s"$messagesPrefix.default"))
 
   override def formRoute(draftId: String, index: Int): Call =
     controllers.property_or_land.routes.RemovePropertyOrLandWithDescriptionController.onSubmit(index, draftId)

--- a/app/controllers/shares/RemoveShareCompanyNameAssetController.scala
+++ b/app/controllers/shares/RemoveShareCompanyNameAssetController.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import models.requests.DataRequest
 import pages.QuestionPage
 import pages.shares.ShareCompanyNamePage
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Call, MessagesControllerComponents}
 import repositories.SessionRepository
 import views.html.RemoveIndexView
@@ -45,12 +45,10 @@ class RemoveShareCompanyNameAssetController @Inject()(
   override val messagesPrefix : String = "removeShareAsset"
 
   override def actions(draftId : String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]) : String =
-    request.userAnswers.get(page(index)).get
+    request.userAnswers.get(page(index)).getOrElse(Messages(s"$messagesPrefix.default"))
 
   override def formRoute(draftId: String, index: Int): Call =
     controllers.shares.routes.RemoveShareCompanyNameAssetController.onSubmit(index, draftId)

--- a/app/controllers/shares/RemoveSharePortfolioAssetController.scala
+++ b/app/controllers/shares/RemoveSharePortfolioAssetController.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import models.requests.DataRequest
 import pages.QuestionPage
 import pages.shares.SharePortfolioNamePage
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Call, MessagesControllerComponents}
 import repositories.SessionRepository
 import views.html.RemoveIndexView
@@ -43,12 +43,10 @@ class RemoveSharePortfolioAssetController @Inject()(
   override val messagesPrefix: String = "removeShareAsset"
 
   override def actions(draftId: String, index: Int) =
-    identify andThen getData(draftId) andThen
-      requireData andThen
-      require(RequiredAnswer(page(index), redirect(draftId)))
+    identify andThen getData(draftId) andThen requireData
 
   override def content(index: Int)(implicit request: DataRequest[AnyContent]): String =
-    request.userAnswers.get(page(index)).get
+    request.userAnswers.get(page(index)).getOrElse(Messages(s"$messagesPrefix.default"))
 
   override def page(index: Int): QuestionPage[String] = SharePortfolioNamePage(index)
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -338,6 +338,7 @@ addATrustee.lead-trustee.required = You need to add or nominate a lead trustee.
 
 removeATrustee.title = Are you sure you want to remove {0}?
 removeATrustee.heading = Are you sure you want to remove {0}?
+removeATrustee.default = the trustee
 removeATrustee.error.required = Select yes if you want to remove the trustee
 
 telephoneNumber.title = What is {0}’s telephone number?
@@ -516,14 +517,17 @@ assetMoneyValue.link = Return to registration progress
 
 removeMoneyAsset.title = Are you sure you want to remove {0}?
 removeMoneyAsset.heading = Are you sure you want to remove {0}?
+removeMoneyAsset.default = the money
 removeMoneyAsset.error.required = Select yes if you want to remove the money
 
 removeShareAsset.title = Are you sure you want to remove {0}?
 removeShareAsset.heading = Are you sure you want to remove {0}?
+removeShareAsset.default = the share
 removeShareAsset.error.required = Select yes if you want to remove the share
 
 removePropertyOrLandAsset.title = Are you sure you want to remove {0}?
 removePropertyOrLandAsset.heading = Are you sure you want to remove {0}?
+removePropertyOrLandAsset.default = the property or land
 removePropertyOrLandAsset.error.required = Select yes if you want to remove the property or land
 
 whatKindOfAsset.first.title = What kind of asset do you need to add first?
@@ -783,6 +787,7 @@ classBeneficiaryDescription.hint = This must be 56 characters or less. For examp
 
 removeClassOfBeneficiary.title = Are you sure you want to remove {0}?
 removeClassOfBeneficiary.heading = Are you sure you want to remove {0}?
+removeClassOfBeneficiary.default = the class of beneficiaries
 removeClassOfBeneficiary.error.required = Select yes if you want to remove the class of beneficiaries
 
 whatTypeOfBeneficiary.first.title = What kind of beneficiary do you need to add first?
@@ -801,6 +806,7 @@ whatTypeOfBeneficiary.hint = You can enter a maximum of 25 entries for each bene
 
 removeIndividualBeneficiary.title = Are you sure you want to remove {0}?
 removeIndividualBeneficiary.heading = Are you sure you want to remove {0}?
+removeIndividualBeneficiary.default = the individual beneficiary
 removeIndividualBeneficiary.error.required = Select yes if you want to remove the individual beneficiary
 
 confirmationPage.title = Registration received, your reference is: {0}

--- a/test/controllers/RemoveClassOfBeneficiaryControllerSpec.scala
+++ b/test/controllers/RemoveClassOfBeneficiaryControllerSpec.scala
@@ -40,27 +40,50 @@ class RemoveClassOfBeneficiaryControllerSpec extends SpecBase with PropertyCheck
 
   val index = 0
 
-  "RemoveClassOfBeneficiary Controller" must {
+  "RemoveClassOfBeneficiary Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no description added" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(ClassBeneficiaryDescriptionPage(0), "Future issues of grandchildren").success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemoveClassOfBeneficiaryController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemoveClassOfBeneficiaryController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the class of beneficiaries", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+    }
+
+    "description is provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(ClassBeneficiaryDescriptionPage(0), "Future issues of grandchildren").success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemoveClassOfBeneficiaryController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/controllers/RemoveIndividualBeneficiaryControllerSpec.scala
+++ b/test/controllers/RemoveIndividualBeneficiaryControllerSpec.scala
@@ -38,27 +38,53 @@ class RemoveIndividualBeneficiaryControllerSpec extends SpecBase with PropertyCh
 
   val index = 0
 
-  "RemoveIndividualBeneficiary Controller" must {
+  "RemoveIndividualBeneficiary Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no name added" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers.set(IndividualBeneficiaryNamePage(0),
-        FullName("First", None, "Last")).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemoveIndividualBeneficiaryController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemoveIndividualBeneficiaryController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "First Last", formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the individual beneficiary", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+
     }
+
+    "name is provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers.set(IndividualBeneficiaryNamePage(0),
+          FullName("First", None, "Last")).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemoveIndividualBeneficiaryController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "First Last", formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
+
+    }
+
 
     "redirect to the next page when valid data is submitted" in {
 

--- a/test/controllers/RemoveTrusteeControllerSpec.scala
+++ b/test/controllers/RemoveTrusteeControllerSpec.scala
@@ -36,29 +36,53 @@ class RemoveTrusteeControllerSpec extends SpecBase with PropertyChecks {
   lazy val formRoute = routes.RemoveTrusteeController.onSubmit(0, fakeDraftId)
 
   lazy val content : String = "John Smith"
+  lazy val defaultContent : String = "the trustee"
 
   val index = 0
 
-  "TrusteeRemove Controller" must {
+  "TrusteeRemove Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no name provided" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(TrusteesNamePage(0), FullName("John", None, "Smith")).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemoveTrusteeController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemoveTrusteeController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, defaultContent, formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+    }
+
+    "name has been provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(TrusteesNamePage(0), FullName("John", None, "Smith")).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemoveTrusteeController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/controllers/money/RemoveMoneyAssetControllerSpec.scala
+++ b/test/controllers/money/RemoveMoneyAssetControllerSpec.scala
@@ -40,28 +40,52 @@ class RemoveMoneyAssetControllerSpec extends SpecBase with PropertyChecks {
 
   val index = 0
 
-  "RemoveMoneyAsset Controller" must {
+  "RemoveMoneyAsset Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no value added" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(AssetMoneyValuePage(0), "200").success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemoveMoneyAssetController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemoveMoneyAssetController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the money", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
     }
+
+    "value has been provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(AssetMoneyValuePage(0), "200").success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemoveMoneyAssetController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
+    }
+
 
     "redirect to the next page when valid data is submitted" in {
 

--- a/test/controllers/property_or_land/RemovePropertyOrLandWithAddressInternationalControllerSpec.scala
+++ b/test/controllers/property_or_land/RemovePropertyOrLandWithAddressInternationalControllerSpec.scala
@@ -41,32 +41,57 @@ class RemovePropertyOrLandWithAddressInternationalControllerSpec extends SpecBas
 
   val index = 0
 
-  "RemovePropertyOrLandWithAddressInternational Controller" must {
+  "RemovePropertyOrLandWithAddressInternational Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no address added" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(PropertyOrLandInternationalAddressPage(0), InternationalAddress(
-          line1 = "line 1",
-          line2 = "line 2",
-          country = "GB"
-        )).success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemovePropertyOrLandWithAddressInternationalController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemovePropertyOrLandWithAddressInternationalController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the property or land", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
     }
+
+    "address has been provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(PropertyOrLandInternationalAddressPage(0), InternationalAddress(
+            line1 = "line 1",
+            line2 = "line 2",
+            country = "GB"
+          )).success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemovePropertyOrLandWithAddressInternationalController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
+    }
+
+
 
     "redirect to the next page when valid data is submitted" in {
 

--- a/test/controllers/property_or_land/RemovePropertyOrLandWithAddressUKControllerSpec.scala
+++ b/test/controllers/property_or_land/RemovePropertyOrLandWithAddressUKControllerSpec.scala
@@ -41,31 +41,54 @@ class RemovePropertyOrLandWithAddressUKControllerSpec extends SpecBase with Prop
 
   val index = 0
 
-  "RemovePropertyOrLandWithAddressUK Controller" must {
+  "RemovePropertyOrLandWithAddressUK Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no address added" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(PropertyOrLandUKAddressPage(0), UKAddress(
-          line1 = "line 1",
-          townOrCity = "Newcastle",
-          postcode = "NE1 1NN"
-        )).success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemovePropertyOrLandWithAddressUKController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemovePropertyOrLandWithAddressUKController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the property or land", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+    }
+
+    "address has been provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(PropertyOrLandUKAddressPage(0), UKAddress(
+            line1 = "line 1",
+            townOrCity = "Newcastle",
+            postcode = "NE1 1NN"
+          )).success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemovePropertyOrLandWithAddressUKController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/controllers/property_or_land/RemovePropertyOrLandWithDescriptionControllerSpec.scala
+++ b/test/controllers/property_or_land/RemovePropertyOrLandWithDescriptionControllerSpec.scala
@@ -41,27 +41,50 @@ class RemovePropertyOrLandWithDescriptionControllerSpec extends SpecBase with Pr
 
   val index = 0
 
-  "RemovePropertyOrLandWithDescription Controller" must {
+  "RemovePropertyOrLandWithDescription Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no description added" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(PropertyOrLandDescriptionPage(0), "2 hectares").success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemovePropertyOrLandWithDescriptionController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemovePropertyOrLandWithDescriptionController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the property or land", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+    }
+
+    "description has been provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(PropertyOrLandDescriptionPage(0), "2 hectares").success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemovePropertyOrLandWithDescriptionController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/controllers/shares/RemoveShareCompanyNameAssetControllerSpec.scala
+++ b/test/controllers/shares/RemoveShareCompanyNameAssetControllerSpec.scala
@@ -40,27 +40,50 @@ class RemoveShareCompanyNameAssetControllerSpec extends SpecBase with PropertyCh
 
   val index = 0
 
-  "RemoveShareAsset Controller" must {
+  "RemoveShareAsset Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no share name provided" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(ShareCompanyNamePage(0), "AWS").success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemoveShareCompanyNameAssetController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemoveShareCompanyNameAssetController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the share", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+    }
+
+    "share name provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(ShareCompanyNamePage(0), "AWS").success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemoveShareCompanyNameAssetController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/controllers/shares/RemoveSharePortfolioAssetControllerSpec.scala
+++ b/test/controllers/shares/RemoveSharePortfolioAssetControllerSpec.scala
@@ -40,27 +40,50 @@ class RemoveSharePortfolioAssetControllerSpec extends SpecBase with PropertyChec
 
   val index = 0
 
-  "RemoveShareAsset Controller" must {
+  "RemoveShareAsset Controller" when {
 
-    "return OK and the correct view for a GET" in {
+    "no name provided" must {
+      "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers
-        .set(SharePortfolioNamePage(0), "AWS Portfolio").success.value
-        .set(AssetStatus(0), Completed).success.value
+        val userAnswers = emptyUserAnswers
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, routes.RemoveSharePortfolioAssetController.onPageLoad(index, fakeDraftId).url)
+        val request = FakeRequest(GET, routes.RemoveSharePortfolioAssetController.onPageLoad(index, fakeDraftId).url)
 
-      val result = route(application, request).value
+        val result = route(application, request).value
 
-      val view = application.injector.instanceOf[RemoveIndexView]
+        val view = application.injector.instanceOf[RemoveIndexView]
 
-      status(result) mustEqual OK
+        status(result) mustEqual OK
 
-      contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, "the share", formRoute)(fakeRequest, messages).toString
 
-      application.stop()
+        application.stop()
+      }
+    }
+
+    "name provided" must {
+      "return OK and the correct view for a GET" in {
+
+        val userAnswers = emptyUserAnswers
+          .set(SharePortfolioNamePage(0), "AWS Portfolio").success.value
+          .set(AssetStatus(0), Completed).success.value
+
+        val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+        val request = FakeRequest(GET, routes.RemoveSharePortfolioAssetController.onPageLoad(index, fakeDraftId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[RemoveIndexView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual view(messagesPrefix, form, index, fakeDraftId, content, formRoute)(fakeRequest, messages).toString
+
+        application.stop()
+      }
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/utils/AddATrusteeViewHelperSpec.scala
+++ b/test/utils/AddATrusteeViewHelperSpec.scala
@@ -66,9 +66,9 @@ class AddATrusteeViewHelperSpec extends SpecBase {
       "generate rows from user answers for trustees in progress" in {
         val rows = new AddATrusteeViewHelper(userAnswersWithTrusteesInProgress, fakeDraftId).rows
         rows.inProgress mustBe List(
-          AddRow("First 0 Last 0", typeLabel = "Trustee", "#", "/trusts-registration/fakeDraftId/trustee/0/remove"),
-          AddRow("First 1 Last 1", typeLabel = "Trustee", "#", "/trusts-registration/fakeDraftId/trustee/1/remove"),
-          AddRow("No name added", typeLabel = "Trustee", "#", "/trusts-registration/fakeDraftId/trustee/2/remove")
+          AddRow("First 0 Last 0", typeLabel = "Trustee", "#", "/trusts-registration/id/trustee/0/remove"),
+          AddRow("First 1 Last 1", typeLabel = "Trustee", "#", "/trusts-registration/id/trustee/1/remove"),
+          AddRow("No name added", typeLabel = "Trustee", "#", "/trusts-registration/id/trustee/2/remove")
         )
         rows.complete mustBe Nil
       }
@@ -76,8 +76,8 @@ class AddATrusteeViewHelperSpec extends SpecBase {
       "generate rows from user answers for complete trustees" in {
         val rows = new AddATrusteeViewHelper(userAnswersWithTrusteesComplete, fakeDraftId).rows
         rows.complete mustBe List(
-          AddRow("First 0 Last 0", typeLabel = "Lead Trustee Individual", "#", "/trusts-registration/fakeDraftId/trustee/0/remove"),
-          AddRow("First 1 Last 1", typeLabel = "Trustee Individual", "#", "/trusts-registration/fakeDraftId/trustee/1/remove")
+          AddRow("First 0 Last 0", typeLabel = "Lead Trustee Individual", "#", "/trusts-registration/id/trustee/0/remove"),
+          AddRow("First 1 Last 1", typeLabel = "Trustee Individual", "#", "/trusts-registration/id/trustee/1/remove")
         )
         rows.inProgress mustBe Nil
       }
@@ -85,10 +85,10 @@ class AddATrusteeViewHelperSpec extends SpecBase {
       "generate rows from user answers for complete and in progress trustees" in {
         val rows = new AddATrusteeViewHelper(userAnswersWithCompleteAndInProgress, fakeDraftId).rows
         rows.complete mustBe List(
-          AddRow("First 1 Last 1", typeLabel = "Lead Trustee Individual", "#", "/trusts-registration/fakeDraftId/trustee/1/remove")
+          AddRow("First 1 Last 1", typeLabel = "Lead Trustee Individual", "#", "/trusts-registration/id/trustee/1/remove")
         )
         rows.inProgress mustBe List(
-          AddRow("First 0 Last 0", typeLabel = "Trustee", "#", "/trusts-registration/fakeDraftId/trustee/0/remove")
+          AddRow("First 0 Last 0", typeLabel = "Trustee", "#", "/trusts-registration/id/trustee/0/remove")
         )
       }
 


### PR DESCRIPTION
For example, now shows 'Do you want to remove the trustee?' if you do not provide the trustees name.