### PR TITLE
[TRUS-905] - Accessibility - VO - Does not fully read error message

### DIFF
--- a/app/views/components/error_summary.scala.html
+++ b/app/views/components/error_summary.scala.html
@@ -16,7 +16,7 @@
 
 @(errors: Seq[FormError])(implicit messages: Messages)
 @if(errors.nonEmpty) {
-    <div id="errors" class="error-summary error-summary--show" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+    <div id="errors" class="error-summary error-summary--show" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
 
         <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
         @messages("error.summary.title")

--- a/app/views/components/error_summary.scala.html
+++ b/app/views/components/error_summary.scala.html
@@ -16,7 +16,7 @@
 
 @(errors: Seq[FormError])(implicit messages: Messages)
 @if(errors.nonEmpty) {
-    <div id="errors" class="error-summary error-summary--show" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+    <div id="errors" class="error-summary error-summary--show" role="alert" tabindex="-1">
 
         <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
         @messages("error.summary.title")


### PR DESCRIPTION
Remove aria-labelledby on error summary component, to prevent VO reading out 'There is a problem' twice.