### PR TITLE
TRUS-2676 Print pages with print buttons, back links and trust details slimmed down

### DIFF
--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -255,20 +255,7 @@ class CheckYourAnswersHelper @Inject()(countryOptions: CountryOptions)
   def trustDetails: Option[Seq[AnswerSection]] = {
     val questions = Seq(
       trustName,
-      whenTrustSetup,
-      governedInsideTheUK,
-      countryGoverningTrust,
-      administrationInsideUK,
-      countryAdministeringTrust,
-      trusteesBasedInUK,
-      settlorsBasedInTheUK,
-      establishedUnderScotsLaw,
-      trustResidentOffshore,
-      trustPreviouslyResident,
-      registeringTrustFor5A,
-      nonresidentType,
-      inheritanceTaxAct,
-      agentOtherThanBarrister
+      whenTrustSetup
     ).flatten
 
     if (questions.nonEmpty) Some(Seq(AnswerSection(None, questions, Some(messages("answerPage.section.trustsDetails.heading"))))) else None

--- a/app/views/components/button_print.scala.html
+++ b/app/views/components/button_print.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@()(implicit messages: Messages)
+
+<button id="print" class="button--secondary print-hidden" onClick="window.print()">
+    @messages("site.print-or-save")
+</button>

--- a/app/views/register/ConfirmationAgentView.scala.html
+++ b/app/views/register/ConfirmationAgentView.scala.html
@@ -39,7 +39,7 @@
         </h1>
     </div>
 
-<p class="panel-indent">@components.link(ConfirmationAnswerPageController.onPageLoad(draftId).url, "print-and-save","confirmationPage.printsave.link", openInNewWindow = true)</p>
+<p class="panel-indent">@components.link(ConfirmationAnswerPageController.onPageLoad(draftId).url, "print-and-save","confirmationPage.printsave.link", openInNewWindow = false)</p>
 
     <h2>@messages("confirmationAgentPage.subheading1")</h2>
 

--- a/app/views/register/ConfirmationAnswerPageView.scala.html
+++ b/app/views/register/ConfirmationAnswerPageView.scala.html
@@ -40,6 +40,8 @@
 
     @components.warning("confirmationAnswerPage")
 
+    <p>@components.button_print()</p>
+
     <div class="two-column-answers">
     @for(section <- answerSections){
         @{

--- a/app/views/register/ConfirmationAnswerPageView.scala.html
+++ b/app/views/register/ConfirmationAnswerPageView.scala.html
@@ -25,13 +25,8 @@
 
 @(answerSections: Seq[Section], trn: String, declarationSent: String)(implicit request: Request[_], messages: Messages)
 
-@printScript = {
-<script type="text/javascript" src='@routes.Assets.versioned("javascripts/print.js")'></script>
-}
-
 @main_template(
-    title = messages("confirmationAnswerPage.title"),
-    scriptElem = Some(printScript)
+    title = messages("confirmationAnswerPage.title")
     ) {
 
     @components.heading("confirmationAnswerPage.heading", headingSize = "heading-xlarge")

--- a/app/views/register/ConfirmationAnswerPageView.scala.html
+++ b/app/views/register/ConfirmationAnswerPageView.scala.html
@@ -29,6 +29,8 @@
     title = messages("confirmationAnswerPage.title")
     ) {
 
+    @components.back_link()
+
     @components.heading("confirmationAnswerPage.heading", headingSize = "heading-xlarge")
 
     <p class="declarationReferenceNumber">
@@ -40,7 +42,9 @@
 
     @components.warning("confirmationAnswerPage")
 
+    <div class="section">
     <p>@components.button_print()</p>
+    </div>
 
     <div class="two-column-answers">
     @for(section <- answerSections){

--- a/app/views/register/ConfirmationExistingView.scala.html
+++ b/app/views/register/ConfirmationExistingView.scala.html
@@ -39,7 +39,7 @@
         </h1>
     </div>
 
-    <p class="panel-indent">@components.link(ConfirmationAnswerPageController.onPageLoad(draftId).url, "print-and-save","confirmationPage.printsave.link", openInNewWindow = true)</p>
+    <p class="panel-indent">@components.link(ConfirmationAnswerPageController.onPageLoad(draftId).url, "print-and-save","confirmationPage.printsave.link", openInNewWindow = false)</p>
 
     <h2>@messages("confirmationExistingPage.subheading1")</h2>
 

--- a/app/views/register/ConfirmationIndividualView.scala.html
+++ b/app/views/register/ConfirmationIndividualView.scala.html
@@ -39,7 +39,7 @@
         </h1>
     </div>
 
-<p class="panel-indent">@components.link(ConfirmationAnswerPageController.onPageLoad(draftId).url, "print-and-save","confirmationPage.printsave.link", openInNewWindow = true)</p>
+<p class="panel-indent">@components.link(ConfirmationAnswerPageController.onPageLoad(draftId).url, "print-and-save","confirmationPage.printsave.link", openInNewWindow = false)</p>
 
     <h2>@messages("confirmationIndividualPage.subheading1")</h2>
 

--- a/app/views/register/SummaryAnswerPageView.scala.html
+++ b/app/views/register/SummaryAnswerPageView.scala.html
@@ -28,17 +28,21 @@
     title = messages("summaryAnswerPage.title")
     ) {
 
+    @components.back_link()
+
     @components.heading("summaryAnswerPage.heading", headingSize = "heading-xlarge")
 
     @if(isAgent) {
         <h2 class="agentClientRef">@messages("answerPage.agentClientRef", agentClientRef)</h2>
     }
 
-    <p>@components.button_print()</p>
-
     <p>@messages("summaryAnswerPage.paragraph1")</p>
 
     <p>@messages("summaryAnswerPage.paragraph2")</p>
+
+    <div class="section">
+    <p>@components.button_print()</p>
+    </div>
 
     <div class="two-column-answers">
     @for(section <- answerSections){

--- a/app/views/register/SummaryAnswerPageView.scala.html
+++ b/app/views/register/SummaryAnswerPageView.scala.html
@@ -34,6 +34,8 @@
         <h2 class="agentClientRef">@messages("answerPage.agentClientRef", agentClientRef)</h2>
     }
 
+    <p>@components.button_print()</p>
+
     <p>@messages("summaryAnswerPage.paragraph1")</p>
 
     <p>@messages("summaryAnswerPage.paragraph2")</p>

--- a/app/views/register/SummaryAnswerPageView.scala.html
+++ b/app/views/register/SummaryAnswerPageView.scala.html
@@ -24,13 +24,8 @@
 
 @(answerSections: Seq[Section], isAgent: Boolean, agentClientRef: String)(implicit request: Request[_], messages: Messages)
 
-@printScript = {
-<script type="text/javascript" src='@routes.Assets.versioned("javascripts/print.js")'></script>
-}
-
 @main_template(
-    title = messages("summaryAnswerPage.title"),
-    scriptElem = Some(printScript)
+    title = messages("summaryAnswerPage.title")
     ) {
 
     @components.heading("summaryAnswerPage.heading", headingSize = "heading-xlarge")

--- a/app/views/register/TaskListView.scala.html
+++ b/app/views/register/TaskListView.scala.html
@@ -51,7 +51,7 @@
         <h2 id="summaryHeading">@messages("taskList.summary.heading1")</h2>
         <div id="summary-paragraph" class="paragraph">
             <p>@messages("taskList.summary.paragraph1.start")
-                @components.link(SummaryAnswerPageController.onPageLoad(draftId).url, "print-and-save", "taskList.summary.link1", openInNewWindow = true)@messages("taskList.summary.paragraph1.end")</p>
+                @components.link(SummaryAnswerPageController.onPageLoad(draftId).url, "print-and-save", "taskList.summary.link1", openInNewWindow = false)@messages("taskList.summary.paragraph1.end")</p>
         </div>
         <h2 id="summaryHeading2">@messages("taskList.summary.heading2")</h2>
         <div id="summary-paragraph-2" class="paragraph">

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -540,7 +540,7 @@ taskList.agent.agentDetails = Agent details
 
 taskList.summary.heading1 = Print a copy
 taskList.summary.paragraph1.start = You can
-taskList.summary.link1 = print or save a draft copy of your saved answers (opens in a new window or tab)
+taskList.summary.link1 = print or save a draft copy of your saved answers
 taskList.summary.paragraph1.end = . You can also print a declared copy after you have made a declaration.
 taskList.summary.heading2 = Update asset details
 taskList.summary.paragraph2 = To update any asset details after making the declaration for this trust, use Self Assessment online or the
@@ -997,7 +997,7 @@ removeIndividualBeneficiary.heading = Are you sure you want to remove {0}?
 removeIndividualBeneficiary.default = the individual beneficiary
 removeIndividualBeneficiary.error.required = Select yes if you want to remove the individual beneficiary
 
-confirmationPage.printsave.link = Print or save a declared copy of the trust’s registration (opens in a new window or tab)
+confirmationPage.printsave.link = Print or save a declared copy of the trust’s registration
 confirmationPage.posthmrc.link = post the changes to HMRC (opens in a new window or tab)
 confirmationPage.contacthmrc.link = contact HMRC to find out why (opens in a new window or tab)
 
@@ -1060,7 +1060,7 @@ confirmationAgentPage.paragraph10.a = contact the trusts helpline (opens in a ne
 confirmationAgentPage.agent.you.can = You can
 confirmationAgentPage.agent.link = return to register and maintain a trust for a client
 
-confirmationPage.printsave.link = Print or save a declared copy of the trust’s registration (opens in a new window or tab)
+confirmationPage.printsave.link = Print or save a declared copy of the trust’s registration
 confirmationPage.posthmrc.link = post the changes to HMRC (opens in a new window or tab)
 confirmationPage.contacthmrc.link = contact HMRC to find out why (opens in a new window or tab)
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -66,6 +66,7 @@ site.confirm-send = Confirm and send
 site.address = Address
 site.utr = Unique Taxpayer Reference
 site.sign_out = Sign out
+site.print-or-save = Print or save this page
 
 featureNotAvailable.title = This part of the online service is not available yet
 featureNotAvailable.heading = This part of the online service is not available yet

--- a/test/controllers/register/ConfirmationAnswersControllerSpec.scala
+++ b/test/controllers/register/ConfirmationAnswersControllerSpec.scala
@@ -133,12 +133,7 @@ class ConfirmationAnswersControllerSpec extends RegistrationSpecBase {
           None,
           Seq(
             checkYourAnswersHelper.trustName.value,
-            checkYourAnswersHelper.whenTrustSetup.value,
-            checkYourAnswersHelper.governedInsideTheUK.value,
-            checkYourAnswersHelper.administrationInsideUK.value,
-            checkYourAnswersHelper.trusteesBasedInUK.value,
-            checkYourAnswersHelper.establishedUnderScotsLaw.value,
-            checkYourAnswersHelper.trustResidentOffshore.value
+            checkYourAnswersHelper.whenTrustSetup.value
           ),
           Some("Trust details")
         ),
@@ -343,12 +338,7 @@ class ConfirmationAnswersControllerSpec extends RegistrationSpecBase {
           None,
           Seq(
             checkYourAnswersHelper.trustName.value,
-            checkYourAnswersHelper.whenTrustSetup.value,
-            checkYourAnswersHelper.governedInsideTheUK.value,
-            checkYourAnswersHelper.administrationInsideUK.value,
-            checkYourAnswersHelper.trusteesBasedInUK.value,
-            checkYourAnswersHelper.establishedUnderScotsLaw.value,
-            checkYourAnswersHelper.trustResidentOffshore.value
+            checkYourAnswersHelper.whenTrustSetup.value
           ),
           Some("Trust details")
         ),

--- a/test/controllers/register/SummaryAnswerPageControllerSpec.scala
+++ b/test/controllers/register/SummaryAnswerPageControllerSpec.scala
@@ -129,12 +129,7 @@ class SummaryAnswerPageControllerSpec extends RegistrationSpecBase {
         None,
         Seq(
           checkYourAnswersHelper.trustName.value,
-          checkYourAnswersHelper.whenTrustSetup.value,
-          checkYourAnswersHelper.governedInsideTheUK.value,
-          checkYourAnswersHelper.administrationInsideUK.value,
-          checkYourAnswersHelper.trusteesBasedInUK.value,
-          checkYourAnswersHelper.establishedUnderScotsLaw.value,
-          checkYourAnswersHelper.trustResidentOffshore.value
+          checkYourAnswersHelper.whenTrustSetup.value
         ),
         Some("Trust details")
       ),
@@ -356,12 +351,7 @@ class SummaryAnswerPageControllerSpec extends RegistrationSpecBase {
         None,
         Seq(
           checkYourAnswersHelper.trustName.value,
-          checkYourAnswersHelper.whenTrustSetup.value,
-          checkYourAnswersHelper.governedInsideTheUK.value,
-          checkYourAnswersHelper.administrationInsideUK.value,
-          checkYourAnswersHelper.trusteesBasedInUK.value,
-          checkYourAnswersHelper.establishedUnderScotsLaw.value,
-          checkYourAnswersHelper.trustResidentOffshore.value
+          checkYourAnswersHelper.whenTrustSetup.value
         ),
         Some("Trust details")
       ),

--- a/test/views/register/ConfirmationAnswerPageViewSpec.scala
+++ b/test/views/register/ConfirmationAnswerPageViewSpec.scala
@@ -158,14 +158,9 @@ class ConfirmationAnswerPageViewSpec extends ViewBehaviours {
       subHeaders.size mustBe 6
     }
 
-    "assert question labels for Trusts" in {
+    "assert question labels for Trust details" in {
       assertContainsQuestionAnswerPair(doc, messages("trustName.checkYourAnswersLabel"), "New Trust")
       assertContainsQuestionAnswerPair(doc, messages("whenTrustSetup.checkYourAnswersLabel"), "10 October 2010")
-      assertContainsQuestionAnswerPair(doc, messages("governedInsideTheUK.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("administrationInsideUK.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("trusteesBasedInTheUK.checkYourAnswersLabel"), "All of the trustees are based in the UK")
-      assertContainsQuestionAnswerPair(doc, messages("establishedUnderScotsLaw.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("trustResidentOffshore.checkYourAnswersLabel"), no)
     }
 
     "assert question labels for Individual Beneficiaries" in {

--- a/test/views/register/SummaryAnswerPageViewSpec.scala
+++ b/test/views/register/SummaryAnswerPageViewSpec.scala
@@ -164,14 +164,9 @@ class SummaryAnswerPageViewSpec extends ViewBehaviours {
       subHeaders.size mustBe 6
     }
 
-    "assert question labels for Trusts" in {
+    "assert question labels for Trust details" in {
       assertContainsQuestionAnswerPair(doc, messages("trustName.checkYourAnswersLabel"), "New Trust")
       assertContainsQuestionAnswerPair(doc, messages("whenTrustSetup.checkYourAnswersLabel"), "10 October 2010")
-      assertContainsQuestionAnswerPair(doc, messages("governedInsideTheUK.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("administrationInsideUK.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("trusteesBasedInTheUK.checkYourAnswersLabel"), "All of the trustees are based in the UK")
-      assertContainsQuestionAnswerPair(doc, messages("establishedUnderScotsLaw.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("trustResidentOffshore.checkYourAnswersLabel"), no)
     }
 
     "assert question labels for Individual Beneficiaries" in {

--- a/test/views/register/settlors/living_settlor/ConfirmationAnswerPageLivingSettlorViewSpec.scala
+++ b/test/views/register/settlors/living_settlor/ConfirmationAnswerPageLivingSettlorViewSpec.scala
@@ -161,11 +161,6 @@ class ConfirmationAnswerPageLivingSettlorViewSpec extends ViewBehaviours {
     "assert question labels for Trusts" in {
       assertContainsQuestionAnswerPair(doc, messages("trustName.checkYourAnswersLabel"), "New Trust")
       assertContainsQuestionAnswerPair(doc, messages("whenTrustSetup.checkYourAnswersLabel"), "10 October 2010")
-      assertContainsQuestionAnswerPair(doc, messages("governedInsideTheUK.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("administrationInsideUK.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("trusteesBasedInTheUK.checkYourAnswersLabel"), "All of the trustees are based in the UK")
-      assertContainsQuestionAnswerPair(doc, messages("establishedUnderScotsLaw.checkYourAnswersLabel"), yes)
-      assertContainsQuestionAnswerPair(doc, messages("trustResidentOffshore.checkYourAnswersLabel"), no)
     }
 
     "assert question labels for Individual Beneficiaries" in {


### PR DESCRIPTION
Service now:
1. has a print this page button on each print screen which is hidden when printed
2. introduces back links on each print page, as these do not now open in a new tab or window

![Screenshot 2020-06-24 at 15 13 08](https://user-images.githubusercontent.com/2979782/85583221-f9e0c280-b635-11ea-8eb2-5925ffefb766.png)
![Screenshot 2020-06-24 at 15 23 19](https://user-images.githubusercontent.com/2979782/85583232-fc431c80-b635-11ea-8f1c-2beada2d388a.png)
![Screenshot 2020-06-24 at 15 26 38](https://user-images.githubusercontent.com/2979782/85583244-fea57680-b635-11ea-95e5-615f9cb174ed.png)
![Screenshot 2020-06-24 at 15 28 20](https://user-images.githubusercontent.com/2979782/85583250-006f3a00-b636-11ea-913b-5bf98a7062c2.png)
![Screenshot 2020-06-24 at 15 33 11](https://user-images.githubusercontent.com/2979782/85583263-02d19400-b636-11ea-9df9-718afd7f78f6.png)
