### PR TITLE
Example Routing split for Non Taxable

### DIFF
--- a/app/controllers/register/TrustHaveAUTRController.scala
+++ b/app/controllers/register/TrustHaveAUTRController.scala
@@ -73,7 +73,7 @@ class TrustHaveAUTRController @Inject()(override val messagesApi: MessagesApi,
             updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustHaveAUTRPage, value))
             _ <- registrationsRepository.set(updatedAnswers)
           } yield {
-            Redirect(navigator.nextPage(TrustHaveAUTRPage, mode, draftId, request.affinityGroup)(updatedAnswers))
+            Redirect(navigator.nextPage(TrustHaveAUTRPage, mode, draftId, None, request.affinityGroup)(updatedAnswers))
           }
         }
       )

--- a/app/controllers/register/trustees/IsThisLeadTrusteeController.scala
+++ b/app/controllers/register/trustees/IsThisLeadTrusteeController.scala
@@ -29,6 +29,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.RegistrationsRepository
 import sections.Trustees
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
+import utils.TrustTypeHelper
 import viewmodels.addAnother.TrusteeViewModel
 import views.html.register.trustees.IsThisLeadTrusteeView
 
@@ -44,7 +45,8 @@ class IsThisLeadTrusteeController @Inject()(
                                              validateIndex : IndexActionFilterProvider,
                                              YesNoFormProvider: YesNoFormProvider,
                                              val controllerComponents: MessagesControllerComponents,
-                                             view: IsThisLeadTrusteeView
+                                             view: IsThisLeadTrusteeView,
+                                             trustTypeHelper: TrustTypeHelper
                                  )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form: Form[Boolean] = YesNoFormProvider.withPrefix("isThisLeadTrustee")
@@ -100,7 +102,16 @@ class IsThisLeadTrusteeController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(IsThisLeadTrusteePage(index), value))
             _              <- registrationsRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(IsThisLeadTrusteePage(index), mode, draftId)(updatedAnswers))
+          } yield {
+              Redirect(
+                navigator.nextPage(
+                  IsThisLeadTrusteePage(index),
+                  mode,
+                  draftId,
+                  trustTypeHelper.isNonTaxable(request.userAnswers)
+                )(updatedAnswers)
+              )
+          }
         }
       )
   }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -35,8 +35,9 @@ class Navigator @Inject()(
     case _ => _ => _ => controllers.register.routes.IndexController.onPageLoad()
   }
 
-  protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
-    ntt match {
+  //TODO - Example 1: Alter the routing here providing an alternate route for non taxable
+  protected def route(draftId: String, isNonTaxable: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    isNonTaxable match {
       case Some(true) => routeNonTaxable(draftId)
       case _          => routeTaxable(draftId)
     }
@@ -62,6 +63,9 @@ class Navigator @Inject()(
       defaultRoute
   }
 
+  //TODO - Example 1: - Pass the taxable trust answer into the navigator here as an option
+  // Where the routing needs to change for non taxable pass in else leave call to nextpage as is and
+  // it will default to taxable
   def nextPage(
                 page: Page,
                 mode: Mode,

--- a/app/navigation/registration/LivingSettlorNavigator.scala
+++ b/app/navigation/registration/LivingSettlorNavigator.scala
@@ -35,9 +35,18 @@ import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
 @Singleton
-class LivingSettlorNavigator @Inject()(config: FrontendAppConfig) extends Navigator(config) {
+class LivingSettlorNavigator @Inject()(
+                                        config: FrontendAppConfig
+                                      ) extends Navigator(config) {
 
-  override protected def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+  override protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    ntt match {
+      case Some(true) => routeNonTaxable(draftId)
+      case _          => routeTaxable(draftId)
+    }
+  }
+
+  override protected def routeTaxable(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
     case SetUpAfterSettlorDiedYesNoPage  => _ => yesNoNav(SetUpAfterSettlorDiedYesNoPage,
       yesCall = controllers.register.settlors.deceased_settlor.routes.SettlorsNameController.onPageLoad(NormalMode, draftId),
       noCall = controllers.register.settlors.living_settlor.routes.KindOfTrustController.onPageLoad(NormalMode, draftId))
@@ -99,6 +108,11 @@ class LivingSettlorNavigator @Inject()(config: FrontendAppConfig) extends Naviga
     case AddASettlorYesNoPage  => _ => yesNoNav(AddASettlorYesNoPage,
       yesCall = routes.SettlorIndividualOrBusinessController.onPageLoad(NormalMode, 0, draftId),
       noCall = controllers.register.routes.TaskListController.onPageLoad(draftId))
+  }
+
+  override protected def routeNonTaxable(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
   }
 
   private def addSettlorRoute(draftId: String)(answers: UserAnswers) = {

--- a/app/navigation/registration/LivingSettlorNavigator.scala
+++ b/app/navigation/registration/LivingSettlorNavigator.scala
@@ -39,8 +39,8 @@ class LivingSettlorNavigator @Inject()(
                                         config: FrontendAppConfig
                                       ) extends Navigator(config) {
 
-  override protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
-    ntt match {
+  override protected def route(draftId: String, isNonTaxable: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    isNonTaxable match {
       case Some(true) => routeNonTaxable(draftId)
       case _          => routeTaxable(draftId)
     }

--- a/app/navigation/registration/PartnershipNavigator.scala
+++ b/app/navigation/registration/PartnershipNavigator.scala
@@ -28,12 +28,26 @@ import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
 @Singleton
-class PartnershipNavigator @Inject()(config: FrontendAppConfig) extends Navigator(config) {
+class PartnershipNavigator @Inject()(
+                                      config: FrontendAppConfig
+                                    ) extends Navigator(config) {
 
-  override protected def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+  override protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    ntt match {
+      case Some(true) => routeNonTaxable(draftId)
+      case _          => routeTaxable(draftId)
+    }
+  }
+
+  override protected def routeTaxable(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
     case PartnershipDescriptionPage(index) => _ => _ => routes.PartnershipStartDateController.onPageLoad(NormalMode, index, draftId)
     case PartnershipStartDatePage(index) => _ => _ => routes.PartnershipAnswerController.onPageLoad(index, draftId)
     case PartnershipAnswerPage => _ => _ => controllers.register.asset.routes.AddAssetsController.onPageLoad(draftId)
+  }
+
+  override protected def routeNonTaxable(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
   }
 
 }

--- a/app/navigation/registration/PartnershipNavigator.scala
+++ b/app/navigation/registration/PartnershipNavigator.scala
@@ -32,8 +32,8 @@ class PartnershipNavigator @Inject()(
                                       config: FrontendAppConfig
                                     ) extends Navigator(config) {
 
-  override protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
-    ntt match {
+  override protected def route(draftId: String, isNonTaxable: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    isNonTaxable match {
       case Some(true) => routeNonTaxable(draftId)
       case _          => routeTaxable(draftId)
     }

--- a/app/navigation/registration/PropertyOrLandNavigator.scala
+++ b/app/navigation/registration/PropertyOrLandNavigator.scala
@@ -28,9 +28,18 @@ import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
 @Singleton
-class PropertyOrLandNavigator @Inject()(config: FrontendAppConfig) extends Navigator(config) {
+class PropertyOrLandNavigator @Inject()(
+                                         config: FrontendAppConfig
+                                       ) extends Navigator(config) {
 
-  override protected def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+  override protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    ntt match {
+      case Some(true) => routeNonTaxable(draftId)
+      case _          => routeTaxable(draftId)
+    }
+  }
+
+  override protected def routeTaxable(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
     case PropertyOrLandAddressYesNoPage(index) => _ => propertyOrLandAddressYesNoPage(draftId, index)
     case PropertyOrLandAddressUkYesNoPage(index) => _ => propertyOrLandAddressUkYesNoPage(draftId, index)
     case PropertyOrLandDescriptionPage(index) => _ => _ => routes.PropertyOrLandTotalValueController.onPageLoad(NormalMode, index, draftId)
@@ -40,6 +49,11 @@ class PropertyOrLandNavigator @Inject()(config: FrontendAppConfig) extends Navig
     case TrustOwnAllThePropertyOrLandPage(index) => _ => trustOwnAllThePropertyOrLandPage(draftId, index)
     case PropertyLandValueTrustPage(index) => _ => _ => routes.PropertyOrLandAnswerController.onPageLoad(index, draftId)
     case PropertyOrLandAnswerPage => _ => _ => controllers.register.asset.routes.AddAssetsController.onPageLoad(draftId)
+  }
+
+  override protected def routeNonTaxable(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
   }
 
   private def propertyOrLandAddressYesNoPage(draftId: String, index: Int)(answers: UserAnswers) = answers.get(PropertyOrLandAddressYesNoPage(index)) match {

--- a/app/navigation/registration/PropertyOrLandNavigator.scala
+++ b/app/navigation/registration/PropertyOrLandNavigator.scala
@@ -32,8 +32,8 @@ class PropertyOrLandNavigator @Inject()(
                                          config: FrontendAppConfig
                                        ) extends Navigator(config) {
 
-  override protected def route(draftId: String, ntt: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
-    ntt match {
+  override protected def route(draftId: String, isNonTaxable: Option[Boolean]): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    isNonTaxable match {
       case Some(true) => routeNonTaxable(draftId)
       case _          => routeTaxable(draftId)
     }

--- a/app/navigation/routes/TrusteeRoutes.scala
+++ b/app/navigation/routes/TrusteeRoutes.scala
@@ -51,6 +51,20 @@ object TrusteeRoutes {
     case AddATrusteePage => _ => addATrusteeRoute(draftId)
     case AddATrusteeYesNoPage => _ => addATrusteeYesNoRoute(draftId)
   }
+
+  //TODO - Example to route based on taxable / non taxable question.
+//  private def addATrusteeYesNoRouteNonTaxableExample(draftId: String)(answers: UserAnswers) : Call = {
+//    (answers.get(TrustTaxableYesNoPage), answers.get(AddATrusteeYesNoPage)) match {
+//      case (Some(false), Some(true)) =>
+//        controllers.register.trustees.routes.IsThisLeadTrusteeController.onPageLoad(NormalMode, 0, draftId)
+//      case (Some(false), Some(false)) =>
+//        routes.TaskListController.onPageLoad(draftId)
+//      case (Some(true), _) =>
+//        controllers.register.trustees.routes.NewNonTaxableQuestionRoutePage.onPageLoad(NormalMode, 0, draftId)
+//      case _ => routes.SessionExpiredController.onPageLoad()
+//    }
+//  }
+
   private def addATrusteeYesNoRoute(draftId: String)(answers: UserAnswers) : Call = {
     answers.get(AddATrusteeYesNoPage) match {
       case Some(true) =>

--- a/app/navigation/routes/TrusteeRoutes.scala
+++ b/app/navigation/routes/TrusteeRoutes.scala
@@ -22,6 +22,7 @@ import models.core.UserAnswers
 import models.core.pages.IndividualOrBusiness
 import models.registration.pages.AddATrustee
 import pages.Page
+import pages.register.IsTrustTaxableYesNoPage
 import pages.register.trustees.individual._
 import pages.register.trustees.organisation._
 import pages.register.trustees._
@@ -52,18 +53,20 @@ object TrusteeRoutes {
     case AddATrusteeYesNoPage => _ => addATrusteeYesNoRoute(draftId)
   }
 
-  //TODO - Example to route based on taxable / non taxable question.
-//  private def addATrusteeYesNoRouteNonTaxableExample(draftId: String)(answers: UserAnswers) : Call = {
-//    (answers.get(TrustTaxableYesNoPage), answers.get(AddATrusteeYesNoPage)) match {
-//      case (Some(false), Some(true)) =>
-//        controllers.register.trustees.routes.IsThisLeadTrusteeController.onPageLoad(NormalMode, 0, draftId)
-//      case (Some(false), Some(false)) =>
-//        routes.TaskListController.onPageLoad(draftId)
-//      case (Some(true), _) =>
-//        controllers.register.trustees.routes.NewNonTaxableQuestionRoutePage.onPageLoad(NormalMode, 0, draftId)
-//      case _ => routes.SessionExpiredController.onPageLoad()
-//    }
-//  }
+  //TODO - Example 2: Route based on taxable / non taxable
+  // question making changes directly to the current routing mechanism.
+  private def addATrusteeYesNoRouteNonTaxableExample(draftId: String)(answers: UserAnswers) : Call = {
+    (answers.get(IsTrustTaxableYesNoPage), answers.get(AddATrusteeYesNoPage)) match {
+      case (Some(false), Some(true)) =>
+        controllers.register.trustees.routes.IsThisLeadTrusteeController.onPageLoad(NormalMode, 0, draftId)
+      case (Some(false), Some(false)) =>
+        routes.TaskListController.onPageLoad(draftId)
+      case (Some(true), _) =>
+        // Simply an example of different routing based on taxable question (need to add new pages and route)
+        controllers.register.trustees.routes.TrusteeIndividualOrBusinessController.onPageLoad(NormalMode, 0, draftId)
+      case _ => routes.SessionExpiredController.onPageLoad()
+    }
+  }
 
   private def addATrusteeYesNoRoute(draftId: String)(answers: UserAnswers) : Call = {
     answers.get(AddATrusteeYesNoPage) match {

--- a/app/navigation/routes/non_taxable/NonTaxableAgentRoutes.scala
+++ b/app/navigation/routes/non_taxable/NonTaxableAgentRoutes.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package navigation
+package navigation.routes.non_taxable
 
-import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
+import pages.Page
 import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+object NonTaxableAgentRoutes {
+  def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
+  }
 }
+
+

--- a/app/navigation/routes/non_taxable/NonTaxableAssetsRoutes.scala
+++ b/app/navigation/routes/non_taxable/NonTaxableAssetsRoutes.scala
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package navigation
+package navigation.routes.non_taxable
 
-import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
+import pages.Page
 import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+object NonTaxableAssetsRoutes {
+  def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
+  }
 }
+

--- a/app/navigation/routes/non_taxable/NonTaxableDeceasedSettlorRoutes.scala
+++ b/app/navigation/routes/non_taxable/NonTaxableDeceasedSettlorRoutes.scala
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package navigation
+package navigation.routes.non_taxable
 
-import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
+import pages.Page
 import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+object NonTaxableDeceasedSettlorRoutes {
+  def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
+  }
 }

--- a/app/navigation/routes/non_taxable/NonTaxableMatchingRoutes.scala
+++ b/app/navigation/routes/non_taxable/NonTaxableMatchingRoutes.scala
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package navigation
+package navigation.routes.non_taxable
 
 import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
+import pages.Page
 import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+object NonTaxableMatchingRoutes {
+  def route(draftId: String, config: FrontendAppConfig): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
+  }
 }
+
+

--- a/app/navigation/routes/non_taxable/NonTaxableTrustDetailRoutes.scala
+++ b/app/navigation/routes/non_taxable/NonTaxableTrustDetailRoutes.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package navigation
+package navigation.routes.non_taxable
 
-import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
+import pages.Page
 import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+object NonTaxableTrustDetailRoutes {
+  def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
+  }
 }
+
+

--- a/app/navigation/routes/non_taxable/NonTaxableTrusteeRoutes.scala
+++ b/app/navigation/routes/non_taxable/NonTaxableTrusteeRoutes.scala
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package navigation
+package navigation.routes.non_taxable
 
-import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
+import pages.Page
 import play.api.mvc.Call
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+object NonTaxableTrusteeRoutes {
+  def route(draftId: String): PartialFunction[Page, AffinityGroup => UserAnswers => Call] = {
+    //TODO - add routing here for NTT
+    ???
+  }
 }

--- a/app/pages/register/IsTrustTaxableYesNoPage.scala
+++ b/app/pages/register/IsTrustTaxableYesNoPage.scala
@@ -1,0 +1,11 @@
+package pages.register
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object IsTrustTaxableYesNoPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "isTrustTaxableYesNo"
+}

--- a/app/utils/TrustTypeHelper.scala
+++ b/app/utils/TrustTypeHelper.scala
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-package navigation
+package utils
 
-import config.FrontendAppConfig
 import models.core.UserAnswers
-import models.{Mode, NormalMode}
-import pages._
-import play.api.mvc.Call
-import uk.gov.hmrc.auth.core.AffinityGroup
 
-class FakeNavigator(config: FrontendAppConfig,
-                    val desiredRoute: Call = Call("GET", "/foo"),
-                    mode: Mode = NormalMode
-                   ) extends Navigator(config) {
-  override def nextPage(page: Page, mode: Mode, fakeDraftId: String, isNonTaxable: Option[Boolean], affinityGroup: AffinityGroup): UserAnswers => Call = _ => desiredRoute
+class TrustTypeHelper {
+
+  def isNonTaxable(userAnswers: UserAnswers): Option[Boolean] = {
+    //TODO - Implement this page: userAnswers.get(TrustTaxableYesNoPage)
+    Some(false)
+  }
+
 }

--- a/app/utils/TrustTypeHelper.scala
+++ b/app/utils/TrustTypeHelper.scala
@@ -17,12 +17,12 @@
 package utils
 
 import models.core.UserAnswers
+import pages.register.IsTrustTaxableYesNoPage
 
 class TrustTypeHelper {
 
   def isNonTaxable(userAnswers: UserAnswers): Option[Boolean] = {
-    //TODO - Implement this page: userAnswers.get(TrustTaxableYesNoPage)
-    Some(false)
+    userAnswers.get(IsTrustTaxableYesNoPage)
   }
 
 }

--- a/test/navigation/navigators/registration/AgentRoutes.scala
+++ b/test/navigation/navigators/registration/AgentRoutes.scala
@@ -37,7 +37,7 @@ trait AgentRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
 
-          navigator.nextPage(AgentInternalReferencePage, NormalMode, fakeDraftId, AffinityGroup.Agent)(userAnswers)
+          navigator.nextPage(AgentInternalReferencePage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(userAnswers)
             .mustBe(routes.AgentNameController.onPageLoad(NormalMode, fakeDraftId))
       }
     }
@@ -46,7 +46,7 @@ trait AgentRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
 
-          navigator.nextPage(AgentNamePage, NormalMode, fakeDraftId, AffinityGroup.Agent)(userAnswers)
+          navigator.nextPage(AgentNamePage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(userAnswers)
             .mustBe(routes.AgentAddressYesNoController.onPageLoad(NormalMode, fakeDraftId))
       }
     }
@@ -55,7 +55,7 @@ trait AgentRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
           val answers = userAnswers.set(AgentAddressYesNoPage, value = true).success.value
-          navigator.nextPage(AgentAddressYesNoPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(answers)
+          navigator.nextPage(AgentAddressYesNoPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(answers)
             .mustBe(routes.AgentUKAddressController.onPageLoad(NormalMode, fakeDraftId))
       }
     }
@@ -63,7 +63,7 @@ trait AgentRoutes {
     "go to AgentTelephoneNumber from AgentUKAddress Page" in {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
-          navigator.nextPage(AgentUKAddressPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(userAnswers)
+          navigator.nextPage(AgentUKAddressPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(userAnswers)
             .mustBe(routes.AgentTelephoneNumberController.onPageLoad(NormalMode, fakeDraftId))
       }
     }
@@ -72,7 +72,7 @@ trait AgentRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
           val answers = userAnswers.set(AgentAddressYesNoPage, value = false).success.value
-          navigator.nextPage(AgentAddressYesNoPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(answers)
+          navigator.nextPage(AgentAddressYesNoPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(answers)
             .mustBe(routes.AgentInternationalAddressController.onPageLoad(NormalMode, fakeDraftId))
       }
     }
@@ -80,7 +80,7 @@ trait AgentRoutes {
     "go to AgentTelephoneNumber from AgentInternationalAddress Page" in {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
-          navigator.nextPage(AgentInternationalAddressPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(userAnswers)
+          navigator.nextPage(AgentInternationalAddressPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(userAnswers)
             .mustBe(routes.AgentTelephoneNumberController.onPageLoad(NormalMode, fakeDraftId))
       }
     }
@@ -89,7 +89,7 @@ trait AgentRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
 
-          navigator.nextPage(AgentTelephoneNumberPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(userAnswers)
+          navigator.nextPage(AgentTelephoneNumberPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(userAnswers)
             .mustBe(routes.AgentAnswerController.onPageLoad(fakeDraftId))
       }
     }
@@ -98,7 +98,7 @@ trait AgentRoutes {
       forAll(arbitrary[UserAnswers]) {
         userAnswers =>
 
-          navigator.nextPage(AgentAnswerPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(userAnswers)
+          navigator.nextPage(AgentAnswerPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(userAnswers)
             .mustBe(controllers.register.routes.TaskListController.onPageLoad(fakeDraftId))
       }
     }

--- a/test/navigation/navigators/registration/MatchingRoutes.scala
+++ b/test/navigation/navigators/registration/MatchingRoutes.scala
@@ -94,7 +94,7 @@ trait MatchingRoutes {
                 val answers = userAnswers.set(TrustRegisteredOnlinePage, false).success.value
                   .set(TrustHaveAUTRPage, false).success.value
 
-                navigator.nextPage(TrustHaveAUTRPage, NormalMode, fakeDraftId, AffinityGroup.Agent)(answers)
+                navigator.nextPage(TrustHaveAUTRPage, NormalMode, fakeDraftId, None, AffinityGroup.Agent)(answers)
                   .mustBe(controllers.register.agents.routes.AgentInternalReferenceController.onPageLoad(NormalMode, fakeDraftId))
             }
           }
@@ -109,7 +109,7 @@ trait MatchingRoutes {
                 val answers = userAnswers.set(TrustRegisteredOnlinePage, false).success.value
                   .set(TrustHaveAUTRPage, false).success.value
 
-                navigator.nextPage(TrustHaveAUTRPage, NormalMode, fakeDraftId, AffinityGroup.Organisation)(answers)
+                navigator.nextPage(TrustHaveAUTRPage, NormalMode, fakeDraftId, None, AffinityGroup.Organisation)(answers)
                   .mustBe(routes.TaskListController.onPageLoad(fakeDraftId))
             }
           }


### PR DESCRIPTION
Example 1: - Pass the taxable trust answer into the navigator as an option and split the routing.

Example 2: - Route based on taxable / non taxable question in the existing routing framework.