### PR TITLE
Aligning money input to reflect latest gov.uk pattern

### DIFF
--- a/app/assets/javascripts/trustsfrontend.js
+++ b/app/assets/javascripts/trustsfrontend.js
@@ -195,20 +195,6 @@ $(document).ready(function() {
 
   function numberInputs() {
       // =====================================================
-      // Set currency fields to number inputs on touch devices
-      // this ensures on-screen keyboards display the correct style
-      // don't do this for FF as it has issues with trailing zeroes
-      // =====================================================
-      if($('html.touchevents').length > 0 && window.navigator.userAgent.indexOf("Firefox") == -1){
-          $('[data-type="currency"] > input[type="text"], [data-type="percentage"] > input[type="text"]').each(function(){
-            $(this).attr('type', 'number');
-            $(this).attr('step', 'any'); 
-            $(this).attr('min', '0');
-            $('form').attr('novalidate','novalidate');
-          });
-      }
-
-      // =====================================================
       // Disable mouse wheel and arrow keys (38,40) for number inputs to prevent mis-entry
       // also disable commas (188) as they will silently invalidate entry on Safari 10.0.3 and IE11
       // =====================================================

--- a/app/views/components/input_text.scala.html
+++ b/app/views/components/input_text.scala.html
@@ -26,7 +26,8 @@
     optionalHtmlContent: Option[Html] = None,
     symbolText: Option[String] = None,
     inputMode: Option[String] = None,
-    autocomplete: Option[String] = None
+    autocomplete: Option[String] = None,
+    pattern: Option[String] = None
 )(implicit messages: Messages)
 
 <div class="form-group @if(field.hasErrors){form-group-error}">
@@ -58,6 +59,9 @@
         }
         @if(inputMode.nonEmpty) {
             inputmode="@{inputMode.get}"
+        }
+        @if(pattern.nonEmpty) {
+        pattern="@{pattern.get}"
         }
         @if(symbolText.nonEmpty) {
             aria-label='@{label} @{symbolText.get}'

--- a/app/views/register/asset/money/AssetMoneyValueView.scala.html
+++ b/app/views/register/asset/money/AssetMoneyValueView.scala.html
@@ -45,7 +45,8 @@
             hint = Some(messages(s"assetMoneyValue.hint")),
             optionalHtmlContent = Some(optionalHtmlContent),
             labelAsHeading = true,
-            inputMode = Some("numeric")
+            inputMode = Some("numeric"),
+            pattern = Some("[0-9]*")
         )
 
         @components.submit_button()


### PR DESCRIPTION
Aligning pattern to follow latest pattern:
https://design-system.service.gov.uk/components/text-input/#numbers

Followed blogpost on pattern https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/