### PR TITLE
Post CR review updates

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -639,7 +639,6 @@ setUpByLivingSettlorYesNo.checkYourAnswersLabel = Was the trust set up by a livi
 settlorAliveYesNo.checkYourAnswersLabel = Is the settlor alive at the time of registration?
 
 settlorIndividualNamePastTense.checkYourAnswersLabel = What was the settlor’s name?
-settlorIndividualDateOfBirthPastTense.checkYourAnswersLabel = What was {0}’s date of birth?
 settlorIndividualUkCountryOfNationalityYesNoPastTense.checkYourAnswersLabel = Did {0} have UK nationality?
 settlorIndividualCountryOfNationalityPastTense.checkYourAnswersLabel = What was {0}’s country of nationality?
 settlorIndividualCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known country of residence?
@@ -648,7 +647,7 @@ settlorIndividualCountryOfResidencyPastTense.checkYourAnswersLabel = What was {0
 settlorIndividualAddressYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known address?
 settlorIndividualAddressInternationalPastTense.checkYourAnswersLabel = What is {0}’s last known address?
 settlorIndividualAddressUKPastTense.checkYourAnswersLabel = What is {0}’s last known address?
-settlorIndividualAddressUKYesNoPastTense.checkYourAnswersLabel = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.checkYourAnswersLabel = Was {0}’s last known address in the UK?
 settlorIndividualIDCardPastTense.checkYourAnswersLabel = What are the details for {0}’s last ID card?
 settlorIndividualPassportPastTense.checkYourAnswersLabel = What are the details for {0}’s last passport?
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -796,7 +796,6 @@ setUpByLivingSettlorYesNo.checkYourAnswersLabel = A gafodd yr ymddiriedolaeth ei
 settlorAliveYesNo.checkYourAnswersLabel = A yw’r setlwr yn fyw ar adeg y cofrestru?
 
 settlorIndividualNamePastTense.checkYourAnswersLabel = Beth oedd enw’r setlwr?
-settlorIndividualDateOfBirthPastTense.checkYourAnswersLabel = Beth oedd dyddiad geni {0}?
 settlorIndividualUkCountryOfNationalityYesNoPastTense.checkYourAnswersLabel = A oedd gan {0} genedligrwydd y DU?
 settlorIndividualCountryOfNationalityPastTense.checkYourAnswersLabel = Beth oedd gwlad cenedligrwydd {0}?
 settlorIndividualCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = A ydych yn gwybod beth oedd gwlad breswyl hysbys ddiwethaf {0}?


### PR DESCRIPTION
Post CR review updates:

The following updates were made to the print draft copy of the trusts registration:
- Add `'s` to `last known address in the UK?` question for deceased settlor
- Revert the `What was the settlor's date of birth?` to `What is the settlor's  date of birth?`


Screenshot of changes
![Screenshot 2023-03-30 at 14 56 46](https://user-images.githubusercontent.com/125281117/228861993-66133277-b45f-413b-8eee-2e47fd3f76f3.png)

