### PR TITLE
DDCE-4481 - Implement optimizely and new pages for A/B testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,31 @@ This service allows users to register or maintain a trust. It asks initial quest
 
 To run locally using the micro-service provided by the service manager:
 
-***sm2 --start TRUSTS_ALL***
+```
+sm2 --start TRUSTS_ALL
+```
 
 alternatively if only the registration journey is needed use:
 
-***sm2 --start REGISTER_TRUST_ALL***
+```
+sm2 --start REGISTER_TRUST_ALL
+```
 
 or if only the maintain journey is needed use:
 
-***sm2 --start MAINTAIN_TRUST_ALL***
+```
+sm2 --start MAINTAIN_TRUST_ALL
+```
 
 If you want to run your local copy, then stop the frontend ran by the service manager and run your local code by using the following (port number is 9781 but is defaulted to that in build.sbt):
 
-***sbt run***
+```sbt run```
+
+Use the following command to run your local copy with the test-only routes:
+
+```
+sbt run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes
+```
 
 ## Testing the service
 Run unit and integration tests before raising a PR to ensure your code changes pass the Jenkins pipeline. This runs all the unit tests and integration tests with scalastyle and checks for dependency updates:
@@ -35,3 +47,11 @@ For example if the settlor is deceased the question `What is the settlor name?` 
 To add a past tense question create a new question with `PastTense` appended to the key for example: `settlorIndividualNamePastTense.checkYourAnswersLabel`.
 
 The past tense question should then be displayed correctly in the print draft of the registration.
+
+### A/B Testing
+
+This service has Optimizely integration.
+
+Pages created for the purpose of A/B testing are under the package name `abTestingUseOnly`. Routes should be prepended with "/a-b/"
+
+Example: `/trusts-registration/a-b/sign-out`

--- a/app/controllers/abTestingUseOnly/TestSignOutController.scala
+++ b/app/controllers/abTestingUseOnly/TestSignOutController.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.abTestingUseOnly
+
+import com.google.inject.Inject
+import config.FrontendAppConfig
+import controllers.actions.register.RegistrationIdentifierAction
+import play.api.Logging
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import utils.Session
+import views.html.abTestingUseOnly.TestSignOutView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TestSignOutController @Inject()(
+                                       val controllerComponents: MessagesControllerComponents,
+                                       identify: RegistrationIdentifierAction,
+                                       view: TestSignOutView,
+                                       appConfig: FrontendAppConfig,
+                                       auditConnector: AuditConnector
+                                     )(implicit val ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
+
+  def onPageLoad(): Action[AnyContent] = identify.async {
+    implicit request =>
+      implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+      if (appConfig.logoutAudit) {
+
+        val auditData = Map(
+          "sessionId" -> Session.id(hc),
+          "event" -> "signout",
+          "service" -> "trusts-frontend",
+          "userGroup" -> request.affinityGroup.toString
+        )
+
+        val auditWithAgent = request.agentARN.fold(auditData) { arn =>
+          auditData ++ Map("agentReferenceNumber" -> arn)
+        }
+
+        auditConnector.sendExplicitAudit(
+          "trusts",
+          auditWithAgent
+        )
+
+      }
+
+      logger.info(s"[TestSignOutController][onPageLoad][Session ID: ${Session.id(hc)}] Displaying TestSignOutView for A/B Testing")
+      Future.successful(Ok(view()))
+  }
+}

--- a/app/controllers/abTestingUseOnly/register/TestConfirmationController.scala
+++ b/app/controllers/abTestingUseOnly/register/TestConfirmationController.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.abTestingUseOnly.register
+
+import controllers.abTestingUseOnly.routes.TestSignOutController
+import controllers.actions.register.{ConfirmationIdentifierAction, DraftIdRetrievalActionProvider, RegistrationDataRequiredAction}
+import controllers.register.routes
+import handlers.ErrorHandler
+import models.core.UserAnswers
+import models.core.http.LeadTrusteeType
+import models.registration.pages.RegistrationStatus
+import models.requests.RegistrationDataRequest
+import pages.register.{RegistrationTRNPage, TrustHaveAUTRPage}
+import play.api.Logging
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import repositories.RegistrationsRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.abTestingUseOnly.register.confirmation._
+import views.html.register.confirmation.{existingTrust, newTrust}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TestConfirmationController @Inject()(
+                                            override val messagesApi: MessagesApi,
+                                            identify: ConfirmationIdentifierAction,
+                                            getData: DraftIdRetrievalActionProvider,
+                                            requireData: RegistrationDataRequiredAction,
+                                            val controllerComponents: MessagesControllerComponents,
+                                            newTaxableIndividualView: newTrust.taxable.IndividualView,
+                                            newTaxableAgentView: newTrust.taxable.AgentView,
+                                            testNonTaxableIndividualView: nonTaxable.TestIndividualView,
+                                            nonTaxableAgentView: newTrust.nonTaxable.AgentView,
+                                            existingTaxableIndividualView: existingTrust.IndividualView,
+                                            existingTaxableAgentView: existingTrust.AgentView,
+                                            errorHandler: ErrorHandler,
+                                            registrationsRepository: RegistrationsRepository
+                                          )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
+
+  def onPageLoad(draftId: String): Action[AnyContent] = (identify andThen getData(draftId) andThen requireData).async {
+    implicit request =>
+      val userAnswers = request.userAnswers
+      handleOutcome(draftId = draftId, userAnswers = userAnswers, methodName = "onPageLoad")
+  }
+
+  def onSubmit(draftId: String): Action[AnyContent] = (identify andThen getData(draftId) andThen requireData).async {
+    implicit request =>
+      val userAnswers = request.userAnswers
+      handleOutcome(draftId = draftId, userAnswers = userAnswers, methodName = "onSubmit", isGetRequest = false)
+  }
+
+  private def handleOutcome(draftId: String, userAnswers: UserAnswers, methodName: String, isGetRequest: Boolean = true)
+                           (implicit request: RegistrationDataRequest[AnyContent]): Future[Result] = {
+    userAnswers.progress match {
+      case RegistrationStatus.Complete =>
+        userAnswers.get(RegistrationTRNPage) match {
+          case None =>
+            infoLogger(methodName, message = "No TRN available for completed trusts. Throwing exception.")
+            errorHandler.onServerError(request, new Exception("TRN is not available for completed trust."))
+          case Some(trn) =>
+            renderViewOrRedirect(trn, userAnswers, draftId, isGetRequest)
+        }
+      case RegistrationStatus.InProgress =>
+        infoLogger(methodName, message = "Registration inProgress status, redirecting to task list.")
+        Future.successful(Redirect(routes.TaskListController.onPageLoad(draftId)))
+      case RegistrationStatus.NotStarted =>
+        infoLogger(methodName, message = "Registration NotStarted status, redirecting to trust registered page online.")
+        Future.successful(Redirect(routes.TrustRegisteredOnlineController.onPageLoad()))
+    }
+  }
+
+  private def renderViewOrRedirect(trn : String, userAnswers: UserAnswers, draftId: String, isGetRequest: Boolean)
+                        (implicit request : RegistrationDataRequest[AnyContent]) : Future[Result] = {
+    val isAgent = request.isAgent
+    registrationsRepository.getLeadTrustee(draftId) flatMap {
+      case LeadTrusteeType(Some(ltInd), None) => renderOrRedirect(userAnswers, draftId, isAgent, trn, ltInd.name.toString, isGetRequest)
+      case LeadTrusteeType(None, Some(ltOrg)) => renderOrRedirect(userAnswers, draftId, isAgent, trn, ltOrg.name, isGetRequest)
+      case _ => errorHandler.onServerError(request, new Exception("Could not retrieve lead trustee from user answers."))
+    }
+  }
+
+  private def renderOrRedirect(userAnswers: UserAnswers, draftId: String, isAgent: Boolean, trn: String, name: String, isGetRequest: Boolean)
+                    (implicit request: RegistrationDataRequest[AnyContent]): Future[Result] = {
+
+    val utr = userAnswers.get(TrustHaveAUTRPage)
+    val taxable = userAnswers.isTaxable
+
+    (utr, taxable) match {
+      case (Some(true), true) if isAgent =>
+        Future.successful(Ok(existingTaxableAgentView(draftId, trn, name)))
+      case (Some(true), true) =>
+        Future.successful(Ok(existingTaxableIndividualView(draftId, trn, name)))
+      case (Some(false), true) if isAgent =>
+        Future.successful(Ok(newTaxableAgentView(draftId, trn, name)))
+      case (Some(false), true) =>
+        Future.successful(Ok(newTaxableIndividualView(draftId, trn, name)))
+      case (Some(false), false) if isAgent =>
+        Future.successful(Ok(nonTaxableAgentView(draftId, trn, name)))
+      case (Some(false), false) =>
+        nonTaxableIndividualResult(draftId, trn, isGetRequest)
+      case _ =>
+        errorHandler.onServerError(request, new Exception("Could not determine if trust was new or existing."))
+    }
+  }
+
+  private def nonTaxableIndividualResult(draftId: String, trn: String, isGetRequest: Boolean)
+                                                (implicit request: RegistrationDataRequest[AnyContent]): Future[Result] = {
+    if(isGetRequest) {
+      infoLogger(methodName = "nonTaxableIndividualResult", message = "TRN available, displaying confirmation page for A/B testing")
+      Future.successful(Ok(testNonTaxableIndividualView(draftId, trn)))
+    } else {
+      infoLogger(methodName = "nonTaxableIndividualResult", message = "Redirecting to TestSignOutController for A/B testing")
+      Future.successful(Redirect(TestSignOutController.onPageLoad()))
+    }
+  }
+
+  private def infoLogger(methodName: String, message: String)(implicit request: RegistrationDataRequest[AnyContent]): Unit = {
+    val className = "TestConfirmationController"
+    logger.info(s"[$className][$methodName][Session ID: ${request.sessionId}] $message")
+  }
+
+}

--- a/app/views/abTestingUseOnly/TestSignOutView.scala.html
+++ b/app/views/abTestingUseOnly/TestSignOutView.scala.html
@@ -1,0 +1,52 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import views.html.components.{Heading, SubmitButton, Link}
+
+@this(
+    mainTemplate: MainTemplate,
+    config: FrontendAppConfig,
+    link: Link,
+    heading: Heading,
+    formHelper: FormWithCSRF,
+    submitButton: SubmitButton
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@mainTemplate(
+title = messages("abTestingUseOnly.signOutPage.title")
+) {
+
+    @heading("abTestingUseOnly.signOutPage.heading", headingSize = "govuk-heading-l")
+
+    <p>@messages("abTestingUseOnly.signOutPage.p1")</p>
+
+    <h2 class="govuk-heading-m">@messages("abTestingUseOnly.signOutPage.heading2")</h2>
+
+    <p>@messages("abTestingUseOnly.signOutPage.p2")</p>
+
+    <p>
+        @link(
+            "https://www.gov.uk/guidance/manage-your-trusts-registration-service",
+            "manage-trust-guidance",
+            "abTestingUseOnly.signOutPage.signIn.link",
+            openInNewWindow = false
+        )
+    </p>
+
+}

--- a/app/views/abTestingUseOnly/register/confirmation/nonTaxable/TestIndividualView.scala.html
+++ b/app/views/abTestingUseOnly/register/confirmation/nonTaxable/TestIndividualView.scala.html
@@ -1,0 +1,76 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import controllers.register.routes.SummaryAnswerPageController
+@import controllers.abTestingUseOnly.register.routes.TestConfirmationController
+@import views.html.components.{Heading, SubmitButton, Link}
+
+@this(
+    mainTemplate: MainTemplate,
+    config: FrontendAppConfig,
+    link: Link,
+    heading: Heading,
+    formHelper: FormWithCSRF,
+    submitButton: SubmitButton
+)
+
+@(draftId: String, refNumber: String)(implicit request: Request[_], messages: Messages)
+
+@mainTemplate(
+    title = messages("abTestingUseOnly.confirmationPage.title")
+) {
+
+    @heading("abTestingUseOnly.confirmationPage.heading", headingSize = "govuk-heading-xl")
+
+    <div class="govuk-inset-text">
+        <p>
+            @link(
+                SummaryAnswerPageController.onPageLoad(draftId).url,
+                "print-or-save",
+                "abTestingUseOnly.confirmationPage.print.link",
+                openInNewWindow = false
+            )
+        </p>
+    </div>
+
+    <h2 class="govuk-heading-l">@messages("abTestingUseOnly.confirmationPage.heading2.WhatNext")</h2>
+
+    <p>@messages("abTestingUseOnly.confirmationPage.p1")</p>
+
+    <p>@messages("abTestingUseOnly.confirmationPage.p2")</p>
+
+    <h3 class="govuk-heading-m">@messages("abTestingUseOnly.confirmationPage.heading3.howToGetURN")</h3>
+
+    <p>@messages("abTestingUseOnly.confirmationPage.p3")</p>
+
+    <h2 class="govuk-heading-m">@messages("abTestingUseOnly.confirmationPage.heading4.contactHMRC")</h2>
+
+    <p>@messages("abTestingUseOnly.confirmationPage.p4")</p>
+
+    <p>
+        <strong>
+            @refNumber
+        </strong>
+    </p>
+
+    <p>@messages("abTestingUseOnly.confirmationPage.p5")</p>
+
+    @formHelper(action = TestConfirmationController.onSubmit(draftId), Symbol("autoComplete") -> "off") {
+        @submitButton(overrideMessage = Some(messages("abTestingUseOnly.confirmationPage.signOut")))
+    }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,13 +52,14 @@ play.filters.csp {
         base-uri = "'self'"
         block-all-mixed-content = ""
         child-src = "'none'"
-        connect-src = "'self' https://www.google-analytics.com https://stats.g.doubleclick.net"
+        connect-src = "'self' https://www.google-analytics.com https://stats.g.doubleclick.net https://logx.optimizely.com https://*.optimizely.com"
         default-src = "'none'"
         frame-ancestors = "'self'"
-        img-src = "'self' https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com https://www.google.com/ads/ga-audiences https://www.google.co.uk/ads/ga-audiences"
+        frame-src = "'self' https://a7589613084.cdn.optimizely.com"
+        img-src = "'self' https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com https://www.google.com/ads/ga-audiences https://www.google.co.uk/ads/ga-audiences https://cdn.optimizely.com"
         font-src = "'self' https://fonts.gstatic.com"
-        script-src = ${play.filters.csp.nonce.pattern} "'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.google-analytics.com https://tagmanager.google.com https://fonts.googleapis.com stats.g.doubleclick.net"
-        style-src = ${play.filters.csp.nonce.pattern} "'self' localhost:9781 localhost:9032 localhost:9250 localhost:12345 https://tagmanager.google.com https://fonts.googleapis.com"
+        script-src = ${play.filters.csp.nonce.pattern} "'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.google-analytics.com https://tagmanager.google.com https://fonts.googleapis.com stats.g.doubleclick.net https://*.optimizely.com https://optimizely.s3.amazonaws.com https://cdn-assets-prod.s3.amazonaws.com"
+        style-src = ${play.filters.csp.nonce.pattern} "'self' localhost:9781 localhost:9032 localhost:9250 localhost:12345 https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline'"
     }
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -1017,3 +1017,25 @@ answerPage.section.businessProtector.subheading = Business protector {0}
 
 answerPage.section.otherIndividuals.heading = Other individuals
 answerPage.section.otherIndividual.subheading = Other individual {0}
+
+# A/B Testing
+
+abTestingUseOnly.confirmationPage.title = Registration submitted
+abTestingUseOnly.confirmationPage.heading = Registration submitted
+abTestingUseOnly.confirmationPage.print.link = Print or save a copy of your answers
+abTestingUseOnly.confirmationPage.heading2.WhatNext = What you must do next
+abTestingUseOnly.confirmationPage.p1 = You need to get the Unique Reference Number (URN) for the trust.
+abTestingUseOnly.confirmationPage.p2 = The URN is how HMRC will identify this trust. You can give the URN to people who are authorised to be involved with managing the trust such as agents, financial advisors and other trustees.
+abTestingUseOnly.confirmationPage.heading3.howToGetURN = How to get the URN for the trust
+abTestingUseOnly.confirmationPage.p3 = You will need to sign out of this service and sign in to manage the trust using the same Government Gateway user ID and password that you set up to register this trust.
+abTestingUseOnly.confirmationPage.heading4.contactHMRC = If you need to contact HMRC
+abTestingUseOnly.confirmationPage.p4 = The reference number for this registration is:
+abTestingUseOnly.confirmationPage.p5 = Keep a note of this reference number in case you need to contact HMRC. It is not the URN for the trust.
+abTestingUseOnly.confirmationPage.signOut = Sign out
+
+abTestingUseOnly.signOutPage.title = You have signed out
+abTestingUseOnly.signOutPage.heading = You have signed out
+abTestingUseOnly.signOutPage.p1 = You have signed out of the trust registration.
+abTestingUseOnly.signOutPage.heading2 = Get the URN for the trust
+abTestingUseOnly.signOutPage.p2 = You need to sign in to manage the trust using the Government Gateway user ID and password that you set up to register this trust.
+abTestingUseOnly.signOutPage.signIn.link = Sign in to manage a trust

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -953,3 +953,25 @@ answerPage.section.businessProtector.subheading = Amddiffynnydd sy’n fusnes {0
 
 answerPage.section.otherIndividuals.heading = Unigolion Eraill
 answerPage.section.otherIndividual.subheading = Unigolyn Arall {0}
+
+# A/B Testing
+
+abTestingUseOnly.confirmationPage.title = Registration submitted
+abTestingUseOnly.confirmationPage.heading = Registration submitted
+abTestingUseOnly.confirmationPage.print.link = Print or save a copy of your answers
+abTestingUseOnly.confirmationPage.heading2.WhatNext = What you must do next
+abTestingUseOnly.confirmationPage.p1 = You need to get the Unique Reference Number (URN) for the trust.
+abTestingUseOnly.confirmationPage.p2 = The URN is how HMRC will identify this trust. You can give the URN to people who are authorised to be involved with managing the trust such as agents, financial advisors and other trustees.
+abTestingUseOnly.confirmationPage.heading3.howToGetURN = How to get the URN for the trust
+abTestingUseOnly.confirmationPage.p3 = You will need to sign out of this service and sign in to manage the trust using the same Government Gateway user ID and password that you set up to register this trust.
+abTestingUseOnly.confirmationPage.heading4.contactHMRC = If you need to contact HMRC
+abTestingUseOnly.confirmationPage.p4 = The reference number for this registration is:
+abTestingUseOnly.confirmationPage.p5 = Keep a note of this reference number in case you need to contact HMRC. It is not the URN for the trust.
+abTestingUseOnly.confirmationPage.signOut = Sign out
+
+abTestingUseOnly.signOutPage.title = You have signed out
+abTestingUseOnly.signOutPage.heading = You have signed out
+abTestingUseOnly.signOutPage.p1 = You have signed out of the trust registration.
+abTestingUseOnly.signOutPage.heading2 = Get the URN for the trust
+abTestingUseOnly.signOutPage.p2 = You need to sign in to manage the trust using the Government Gateway user ID and password that you set up to register this trust.
+abTestingUseOnly.signOutPage.signIn.link = Sign in to manage a trust

--- a/conf/register.routes
+++ b/conf/register.routes
@@ -100,3 +100,11 @@ GET        /:draftId/remove                             controllers.register.age
 POST       /:draftId/remove                             controllers.register.agents.RemoveDraftYesNoController.onSubmit(draftId: String)
 
 GET        /feature-not-available                       controllers.FeatureNotAvailableController.onPageLoad()
+
+## A/B Testing Routes
+
+GET        /a-b/:draftId/confirmation                   controllers.abTestingUseOnly.register.TestConfirmationController.onPageLoad(draftId: String)
+
+POST       /a-b/:draftId/confirmation                   controllers.abTestingUseOnly.register.TestConfirmationController.onSubmit(draftId: String)
+
+GET        /a-b/sign-out                                controllers.abTestingUseOnly.TestSignOutController.onPageLoad()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,4 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-->         /                          prod.Routes
+->         /                                                            prod.Routes

--- a/test/controllers/abTestingUseOnly/TestSignOutControllerSpec.scala
+++ b/test/controllers/abTestingUseOnly/TestSignOutControllerSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.abTestingUseOnly
+
+import base.RegistrationSpecBase
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.inject.bind
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import views.html.abTestingUseOnly.TestSignOutView
+
+class TestSignOutControllerSpec extends RegistrationSpecBase {
+
+  "TestSignOutController" must {
+
+    "render the test sign out view and send audit for /GET" in {
+
+      val mockAuditConnector = mock[AuditConnector]
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+        .overrides(bind[AuditConnector].toInstance(mockAuditConnector))
+        .build()
+
+      val request = FakeRequest(GET, routes.TestSignOutController.onPageLoad().url)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[TestSignOutView]
+
+      status(result) mustEqual OK
+
+      contentAsString(result) mustEqual view()(request, messages).toString
+
+      verify(mockAuditConnector, never)
+        .sendExplicitAudit(eqTo("trusts"), any[Map[String, String]])(any(), any())
+
+      application.stop()
+    }
+  }
+
+}

--- a/test/views/abTestingUseOnly/TestSignOutViewSpec.scala
+++ b/test/views/abTestingUseOnly/TestSignOutViewSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.abTestingUseOnly
+
+import play.twirl.api.HtmlFormat
+import views.behaviours.ViewBehaviours
+import views.html.abTestingUseOnly.TestSignOutView
+
+class TestSignOutViewSpec extends ViewBehaviours {
+
+  private val messageKeyPrefix = "abTestingUseOnly.signOutPage"
+  private val guidanceURL = "https://www.gov.uk/guidance/manage-your-trusts-registration-service"
+
+  "TestSignOutView" must {
+
+    val view = viewFor[TestSignOutView](None)
+
+    def applyView(): HtmlFormat.Appendable = view.apply()(fakeRequest, messages)
+
+    behave like normalPage(applyView(), None, messageKeyPrefix)
+
+    behave like pageWithLink(applyView(), "manage-trust-guidance", guidanceURL)
+
+    behave like pageWithText(applyView(), "You have signed out", "- heading")
+    behave like pageWithText(applyView(), "You have signed out of the trust registration.", "- p1")
+    behave like pageWithText(applyView(), "Get the URN for the trust", "- heading2")
+    behave like pageWithText(applyView(), "You need to sign in to manage the trust using the Government Gateway user " +
+      "ID and password that you set up to register this trust.", "- p2")
+    behave like pageWithText(applyView(), "Sign in to manage a trust", "- link text")
+  }
+
+}

--- a/test/views/abTestingUseOnly/register/confirmation/nonTaxable/TestIndividualViewSpec.scala
+++ b/test/views/abTestingUseOnly/register/confirmation/nonTaxable/TestIndividualViewSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.abTestingUseOnly.register.confirmation.nonTaxable
+
+import play.twirl.api.HtmlFormat
+import views.behaviours.ViewBehaviours
+import views.html.abTestingUseOnly.register.confirmation.nonTaxable.TestIndividualView
+
+class TestIndividualViewSpec extends ViewBehaviours {
+
+  private val refNumber = "X1234567890YZ"
+  private val messageKeyPrefix = "abTestingUseOnly.confirmationPage"
+  private val printOrSaveLink = s"/trusts-registration/$fakeDraftId/your-draft-registration"
+
+  "TestIndividualView" must {
+
+    val view = viewFor[TestIndividualView](Some(emptyUserAnswers))
+
+    def applyView(): HtmlFormat.Appendable = view.apply(fakeDraftId, refNumber)(fakeRequest, messages)
+
+    behave like normalPage(applyView(), None, messageKeyPrefix)
+
+    behave like pageWithLink(applyView(), "print-or-save", printOrSaveLink)
+
+    behave like pageWithText(applyView(), "Registration submitted", "- heading")
+    behave like pageWithText(applyView(), "Print or save a copy of your answers", "- link text")
+    behave like pageWithText(applyView(), "What you must do next", "- heading 2")
+    behave like pageWithText(applyView(), "You need to get the Unique Reference Number (URN) for the trust.", "- p1")
+    behave like pageWithText(applyView(), "The URN is how HMRC will identify this trust. You can give the URN to people who " +
+      "are authorised to be involved with managing the trust such as agents, financial advisors and other trustees.", "- p2")
+    behave like pageWithText(applyView(), "How to get the URN for the trust", "- heading 3")
+    behave like pageWithText(applyView(), "You will need to sign out of this service and sign in to manage the trust using the " +
+      "same Government Gateway user ID and password that you set up to register this trust.", "- p3")
+    behave like pageWithText(applyView(), "If you need to contact HMRC", "- heading 4")
+    behave like pageWithText(applyView(), "The reference number for this registration is:", "- p4")
+    behave like pageWithText(applyView(), refNumber, "ref number")
+    behave like pageWithText(applyView(), "Keep a note of this reference number in case you need to contact HMRC. It is not the " +
+      "URN for the trust.", "- p5")
+    behave like pageWithText(applyView(), "Sign out", "- button text")
+
+    behave like pageWithASubmitButton(applyView())
+  }
+}

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -332,9 +332,10 @@ trait ViewBehaviours extends ViewSpecBase {
   }
 
   def pageWithText[A](view: HtmlFormat.Appendable,
-                      text: String): Unit = {
+                      text: String,
+                      testDescription: String = ""): Unit = {
 
-    "behave like a page with content" in {
+    s"behave like a page with content $testDescription" in {
 
       val doc = asDocument(view)
       assertContainsText(doc, text)


### PR DESCRIPTION
Changes:

- Added two new pages for A/B testing: test confirmation page, test sign out page
- Updated CSP to include Optimizely
- Updated ReadMe

**Accessing new pages**
Complete the trusts registration page as a non-taxable organisation user group. When you reach the confirmation page, change the URL to the route for TestConfirmationController