### PR TITLE
DDCE-5067: Update to stop form submission with smart apostrophes

### DIFF
--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -43,8 +43,7 @@ trait Formatters {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
       data.get(key) match {
         case None | Some("") => Left(Seq(FormError(key, errorKey)))
-        case Some(s) =>
-          Right(s.trim)
+        case Some(s) => Right(s.trim.replace("‘", "'").replace("’", "'"))
       }
 
     override def unbind(key: String, value: String): Map[String, String] =

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,17 +2,17 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.22.0"
-  val mongoVersion = "1.3.0"
+  val bootstrapVersion = "7.23.0"
+  val mongoVersion = "1.7.0"
 
   private val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"     % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % mongoVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "7.23.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "7.29.0-play-28",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "1.13.0-play-28",
     "uk.gov.hmrc"       %% "domain"                         % "8.3.0-play-28",
-    "uk.gov.hmrc"       %% "tax-year"                       % "3.3.0",
+    "uk.gov.hmrc"       %% "tax-year"                       % "4.0.0",
     "org.typelevel"     %% "cats-core"                      % "2.10.0"
   )
 
@@ -20,11 +20,11 @@ object AppDependencies {
     "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"  % mongoVersion,
     "org.scalatest"           %% "scalatest"                % "3.2.17",
-    "org.jsoup"               %  "jsoup"                    % "1.16.1",
-    "org.mockito"             %% "mockito-scala-scalatest"  % "1.17.27",
+    "org.jsoup"               %  "jsoup"                    % "1.17.2",
+    "org.mockito"             %% "mockito-scala-scalatest"  % "1.17.30",
     "org.scalatestplus"       %% "scalacheck-1-17"          % "3.2.17.0",
     "io.github.wolfendale"    %% "scalacheck-gen-regexp"    % "1.1.0",
-    "org.wiremock"            %  "wiremock-standalone"      % "3.2.0",
+    "org.wiremock"            %  "wiremock-standalone"      % "3.3.1",
     "com.vladsch.flexmark"    %  "flexmark-all"             % "0.64.8"
   ).map(_ % "test, it")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,9 +7,9 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.20.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"  % "2.2.0")
-addSbtPlugin("com.typesafe.play"    % "sbt-plugin"          % "2.8.20")
+addSbtPlugin("com.typesafe.play"    % "sbt-plugin"          % "2.8.21")
 addSbtPlugin("com.beautiful-scala"  % "sbt-scalastyle"      % "1.5.1")
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"       % "2.0.9")
 addSbtPlugin("io.github.irundaia"   % "sbt-sassify"         % "1.5.2")

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -53,6 +53,11 @@ class MappingsSpec extends AnyWordSpec with Matchers with OptionValues with Mapp
       result.get mustEqual "foobar"
     }
 
+    "filter out smart apostrophes on binding" in {
+      val boundValue = testForm bind Map("value" -> "We’re ‘aving fish ‘n’ chips for tea")
+      boundValue.get mustEqual "We're 'aving fish 'n' chips for tea"
+    }
+
     "bind and trim spaces" in {
       val result = testForm.bind(Map("value" -> "   foobar     "))
       result.get mustEqual "foobar"


### PR DESCRIPTION
Update to make smart apostrophes be replaces with non smart ones.

Screen shots of  data in mongo and form submission:
![Screenshot 2024-02-02 at 11 32 09](https://github.com/hmrc/trusts-frontend/assets/125281117/ce593d38-7556-4bfd-ae97-550d74db5a89)

![Screenshot 2024-02-02 at 11 30 40](https://github.com/hmrc/trusts-frontend/assets/125281117/a7579512-ace8-4e8d-8ec0-7d6b4739953f)
